### PR TITLE
Use stable Go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ckb
 
-go 1.24.6
+go 1.22.5
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary
- align module with stable Go 1.22.5 toolchain instead of unreleased 1.24.6

## Testing
- go test ./... (fails: go mod tidy required)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941960030f083259f8c6ec0e3573b13)