### PR TITLE
Add v6.0 Architectural Memory Phase 1 foundation

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -416,6 +416,32 @@ func (s *MCPServer) GetToolDefinitions() []Tool {
 				},
 			},
 		},
+		// v6.0 Architectural Memory tools
+		{
+			Name:        "refreshArchitecture",
+			Description: "Rebuild the architectural model from sources. Use this to refresh ownership, modules, hotspots, or responsibilities data. Heavy operation (up to 30s).",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"scope": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"all", "modules", "ownership", "hotspots", "responsibilities"},
+						"default":     "all",
+						"description": "What to refresh: 'all' (default), 'modules', 'ownership', 'hotspots', or 'responsibilities'",
+					},
+					"force": map[string]interface{}{
+						"type":        "boolean",
+						"default":     false,
+						"description": "Force refresh even if data is fresh",
+					},
+					"dryRun": map[string]interface{}{
+						"type":        "boolean",
+						"default":     false,
+						"description": "Preview what would be refreshed without making changes",
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -440,4 +466,6 @@ func (s *MCPServer) RegisterTools() {
 	s.tools["explainPath"] = s.toolExplainPath
 	s.tools["listKeyConcepts"] = s.toolListKeyConcepts
 	s.tools["recentlyRelevant"] = s.toolRecentlyRelevant
+	// v6.0 Architectural Memory tools
+	s.tools["refreshArchitecture"] = s.toolRefreshArchitecture
 }

--- a/internal/modules/declaration.go
+++ b/internal/modules/declaration.go
@@ -1,0 +1,290 @@
+package modules
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	toml "github.com/pelletier/go-toml/v2"
+
+	"ckb/internal/paths"
+)
+
+// ModulesDeclarationFile is the default filename for module declarations
+const ModulesDeclarationFile = "MODULES.toml"
+
+// ModuleDeclaration represents a declared module in MODULES.toml
+type ModuleDeclaration struct {
+	// ID is the unique module identifier (optional, will be generated if not provided)
+	ID string `toml:"id"`
+
+	// Name is the human-readable name of the module
+	Name string `toml:"name"`
+
+	// Path is the repo-relative path to the module root
+	Path string `toml:"path"`
+
+	// Responsibility is a one-line description of what this module does
+	Responsibility string `toml:"responsibility,omitempty"`
+
+	// Boundaries defines the module's API surface
+	Boundaries *BoundaryDeclaration `toml:"boundaries,omitempty"`
+
+	// Owner is the owner reference (e.g., @team-name or user@email.com)
+	Owner string `toml:"owner,omitempty"`
+
+	// Tags are classification tags for the module
+	Tags []string `toml:"tags,omitempty"`
+
+	// Language is the primary language of the module (optional, will be detected)
+	Language string `toml:"language,omitempty"`
+}
+
+// BoundaryDeclaration defines module boundaries/API surface
+type BoundaryDeclaration struct {
+	// Exports are the public APIs exposed by this module
+	Exports []string `toml:"exports,omitempty"`
+
+	// Internal are paths that are considered internal/private
+	Internal []string `toml:"internal,omitempty"`
+
+	// AllowedDependencies are modules this module is allowed to depend on
+	AllowedDependencies []string `toml:"allowed_dependencies,omitempty"`
+}
+
+// ModulesFile represents the root structure of MODULES.toml
+type ModulesFile struct {
+	// Version is the schema version
+	Version int `toml:"version"`
+
+	// Modules is the list of declared modules
+	Modules []ModuleDeclaration `toml:"module"`
+}
+
+// ParseModulesFile parses a MODULES.toml file from the given path
+func ParseModulesFile(filePath string) (*ModulesFile, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read MODULES.toml: %w", err)
+	}
+
+	var modulesFile ModulesFile
+	if err := toml.Unmarshal(data, &modulesFile); err != nil {
+		return nil, fmt.Errorf("failed to parse MODULES.toml: %w", err)
+	}
+
+	// Validate version
+	if modulesFile.Version < 1 {
+		modulesFile.Version = 1 // Default to version 1
+	}
+
+	return &modulesFile, nil
+}
+
+// LoadDeclaredModules loads declared modules from MODULES.toml if it exists
+func LoadDeclaredModules(repoRoot string, declarationFile string, stateId string) ([]*Module, error) {
+	if declarationFile == "" {
+		declarationFile = ModulesDeclarationFile
+	}
+
+	filePath := filepath.Join(repoRoot, declarationFile)
+
+	// Check if file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil, nil // No declared modules file
+	}
+
+	modulesFile, err := ParseModulesFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertDeclarationsToModules(repoRoot, modulesFile.Modules, stateId)
+}
+
+// convertDeclarationsToModules converts ModuleDeclarations to Module structs
+func convertDeclarationsToModules(repoRoot string, declarations []ModuleDeclaration, stateId string) ([]*Module, error) {
+	var modules []*Module
+
+	for _, decl := range declarations {
+		// Validate required fields
+		if decl.Path == "" {
+			return nil, fmt.Errorf("module declaration missing required 'path' field")
+		}
+
+		// Generate ID if not provided
+		moduleID := decl.ID
+		if moduleID == "" {
+			moduleID = GenerateStableModuleID(repoRoot, decl.Path)
+		}
+
+		// Use path as name if name not provided
+		name := decl.Name
+		if name == "" {
+			parts := strings.Split(decl.Path, "/")
+			name = parts[len(parts)-1]
+		}
+
+		// Detect language if not specified
+		language := decl.Language
+		if language == "" {
+			absPath := filepath.Join(repoRoot, decl.Path)
+			language = detectLanguageFromFiles(absPath)
+		}
+
+		// Detect manifest if present
+		absPath := filepath.Join(repoRoot, decl.Path)
+		manifest, _ := detectManifestInDir(absPath)
+
+		module := &Module{
+			ID:           moduleID,
+			Name:         name,
+			RootPath:     decl.Path,
+			ManifestType: manifest,
+			Language:     language,
+			DetectedAt:   time.Now().UTC().Format(time.RFC3339),
+			StateId:      stateId,
+		}
+		modules = append(modules, module)
+	}
+
+	return modules, nil
+}
+
+// DeclarationMetadata holds the v6.0 metadata from a module declaration
+type DeclarationMetadata struct {
+	ModuleID       string
+	Responsibility string
+	Boundaries     *BoundaryDeclaration
+	Owner          string
+	Tags           []string
+}
+
+// ExtractMetadataFromDeclarations extracts v6.0 metadata from declarations
+func ExtractMetadataFromDeclarations(filePath string) (map[string]*DeclarationMetadata, error) {
+	modulesFile, err := ParseModulesFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata := make(map[string]*DeclarationMetadata)
+
+	for _, decl := range modulesFile.Modules {
+		moduleID := decl.ID
+		if moduleID == "" {
+			// Generate ID from path for lookup
+			moduleID = GenerateStableModuleID("", decl.Path)
+		}
+
+		metadata[moduleID] = &DeclarationMetadata{
+			ModuleID:       moduleID,
+			Responsibility: decl.Responsibility,
+			Boundaries:     decl.Boundaries,
+			Owner:          decl.Owner,
+			Tags:           decl.Tags,
+		}
+	}
+
+	return metadata, nil
+}
+
+// WriteModulesFile writes a ModulesFile to the given path
+func WriteModulesFile(filePath string, modulesFile *ModulesFile) error {
+	data, err := toml.Marshal(modulesFile)
+	if err != nil {
+		return fmt.Errorf("failed to marshal MODULES.toml: %w", err)
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write MODULES.toml: %w", err)
+	}
+
+	return nil
+}
+
+// CreateExampleModulesFile creates an example MODULES.toml file
+func CreateExampleModulesFile(filePath string) error {
+	example := &ModulesFile{
+		Version: 1,
+		Modules: []ModuleDeclaration{
+			{
+				Name:           "api",
+				Path:           "internal/api",
+				Responsibility: "HTTP API handlers and middleware",
+				Owner:          "@api-team",
+				Tags:           []string{"core", "api"},
+				Boundaries: &BoundaryDeclaration{
+					Exports:             []string{"Handler", "Middleware"},
+					Internal:            []string{"internal/api/internal"},
+					AllowedDependencies: []string{"internal/query", "internal/storage"},
+				},
+			},
+			{
+				Name:           "query",
+				Path:           "internal/query",
+				Responsibility: "Query engine for code intelligence",
+				Owner:          "@platform-team",
+				Tags:           []string{"core", "query"},
+			},
+		},
+	}
+
+	return WriteModulesFile(filePath, example)
+}
+
+// GenerateStableModuleID generates a stable module ID that survives renames
+// Format: ckb:mod:<hash>
+// The hash is based on the normalized path
+func GenerateStableModuleID(repoRoot string, modulePath string) string {
+	// Normalize path
+	normalizedPath := paths.NormalizePath(modulePath)
+
+	// For declared modules, we use a simpler hash based on path
+	// This allows the ID to be regenerated deterministically
+	hash := sha256.Sum256([]byte(normalizedPath))
+	hashStr := hex.EncodeToString(hash[:8]) // Use first 8 bytes for shorter ID
+
+	return fmt.Sprintf("ckb:mod:%s", hashStr)
+}
+
+// ModuleIDFromPath generates a module ID for lookup purposes
+// This is the same algorithm used in GenerateStableModuleID
+func ModuleIDFromPath(modulePath string) string {
+	return GenerateStableModuleID("", modulePath)
+}
+
+// ParseModuleID extracts components from a module ID
+// Returns (prefix, hash, isValid)
+func ParseModuleID(moduleID string) (prefix string, hash string, isValid bool) {
+	if !strings.HasPrefix(moduleID, "ckb:mod:") {
+		return "", "", false
+	}
+
+	parts := strings.Split(moduleID, ":")
+	if len(parts) != 3 {
+		return "", "", false
+	}
+
+	// Hash must not be empty
+	if parts[2] == "" {
+		return "", "", false
+	}
+
+	return parts[0] + ":" + parts[1], parts[2], true
+}
+
+// IsValidModuleID checks if a string is a valid module ID
+func IsValidModuleID(moduleID string) bool {
+	_, _, isValid := ParseModuleID(moduleID)
+	return isValid
+}

--- a/internal/modules/declaration_test.go
+++ b/internal/modules/declaration_test.go
@@ -1,0 +1,368 @@
+package modules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseModulesFile(t *testing.T) {
+	// Create a temp directory
+	tempDir, err := os.MkdirTemp("", "ckb-modules-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a MODULES.toml file
+	modulesContent := `
+version = 1
+
+[[module]]
+name = "api"
+path = "internal/api"
+responsibility = "HTTP API handlers"
+owner = "@api-team"
+tags = ["core", "api"]
+
+[[module]]
+name = "query"
+path = "internal/query"
+responsibility = "Query engine"
+owner = "@platform-team"
+
+[module.boundaries]
+exports = ["Engine", "Query"]
+internal = ["internal/query/private"]
+allowed_dependencies = ["internal/storage"]
+`
+
+	modulesPath := filepath.Join(tempDir, "MODULES.toml")
+	if err := os.WriteFile(modulesPath, []byte(modulesContent), 0644); err != nil {
+		t.Fatalf("Failed to write MODULES.toml: %v", err)
+	}
+
+	// Parse the file
+	modulesFile, err := ParseModulesFile(modulesPath)
+	if err != nil {
+		t.Fatalf("Failed to parse MODULES.toml: %v", err)
+	}
+
+	// Verify version
+	if modulesFile.Version != 1 {
+		t.Errorf("Expected version 1, got %d", modulesFile.Version)
+	}
+
+	// Verify module count
+	if len(modulesFile.Modules) != 2 {
+		t.Errorf("Expected 2 modules, got %d", len(modulesFile.Modules))
+	}
+
+	// Verify first module
+	api := modulesFile.Modules[0]
+	if api.Name != "api" {
+		t.Errorf("Expected name 'api', got '%s'", api.Name)
+	}
+	if api.Path != "internal/api" {
+		t.Errorf("Expected path 'internal/api', got '%s'", api.Path)
+	}
+	if api.Responsibility != "HTTP API handlers" {
+		t.Errorf("Expected responsibility 'HTTP API handlers', got '%s'", api.Responsibility)
+	}
+	if api.Owner != "@api-team" {
+		t.Errorf("Expected owner '@api-team', got '%s'", api.Owner)
+	}
+	if len(api.Tags) != 2 {
+		t.Errorf("Expected 2 tags, got %d", len(api.Tags))
+	}
+
+	// Verify second module with boundaries
+	query := modulesFile.Modules[1]
+	if query.Name != "query" {
+		t.Errorf("Expected name 'query', got '%s'", query.Name)
+	}
+	if query.Boundaries == nil {
+		t.Error("Expected boundaries to be set")
+	} else {
+		if len(query.Boundaries.Exports) != 2 {
+			t.Errorf("Expected 2 exports, got %d", len(query.Boundaries.Exports))
+		}
+		if len(query.Boundaries.Internal) != 1 {
+			t.Errorf("Expected 1 internal path, got %d", len(query.Boundaries.Internal))
+		}
+		if len(query.Boundaries.AllowedDependencies) != 1 {
+			t.Errorf("Expected 1 allowed dependency, got %d", len(query.Boundaries.AllowedDependencies))
+		}
+	}
+}
+
+func TestLoadDeclaredModules(t *testing.T) {
+	// Create a temp directory with module structure
+	tempDir, err := os.MkdirTemp("", "ckb-modules-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create module directories
+	apiDir := filepath.Join(tempDir, "internal", "api")
+	queryDir := filepath.Join(tempDir, "internal", "query")
+	if err := os.MkdirAll(apiDir, 0755); err != nil {
+		t.Fatalf("Failed to create api dir: %v", err)
+	}
+	if err := os.MkdirAll(queryDir, 0755); err != nil {
+		t.Fatalf("Failed to create query dir: %v", err)
+	}
+
+	// Create a Go file in api dir to help with language detection
+	if err := os.WriteFile(filepath.Join(apiDir, "handler.go"), []byte("package api"), 0644); err != nil {
+		t.Fatalf("Failed to write handler.go: %v", err)
+	}
+
+	// Create a MODULES.toml file
+	modulesContent := `
+version = 1
+
+[[module]]
+name = "api"
+path = "internal/api"
+responsibility = "HTTP API handlers"
+
+[[module]]
+path = "internal/query"
+`
+
+	modulesPath := filepath.Join(tempDir, "MODULES.toml")
+	if err := os.WriteFile(modulesPath, []byte(modulesContent), 0644); err != nil {
+		t.Fatalf("Failed to write MODULES.toml: %v", err)
+	}
+
+	// Load declared modules
+	modules, err := LoadDeclaredModules(tempDir, "", "test-state")
+	if err != nil {
+		t.Fatalf("Failed to load declared modules: %v", err)
+	}
+
+	// Verify module count
+	if len(modules) != 2 {
+		t.Errorf("Expected 2 modules, got %d", len(modules))
+	}
+
+	// Verify first module has a stable ID
+	if modules[0].ID == "" {
+		t.Error("Expected module ID to be generated")
+	}
+	if modules[0].Name != "api" {
+		t.Errorf("Expected name 'api', got '%s'", modules[0].Name)
+	}
+
+	// Verify second module uses path as name
+	if modules[1].Name != "query" {
+		t.Errorf("Expected name 'query' (from path), got '%s'", modules[1].Name)
+	}
+
+	// Verify state ID is set
+	if modules[0].StateId != "test-state" {
+		t.Errorf("Expected state ID 'test-state', got '%s'", modules[0].StateId)
+	}
+}
+
+func TestLoadDeclaredModulesNoFile(t *testing.T) {
+	// Create a temp directory without MODULES.toml
+	tempDir, err := os.MkdirTemp("", "ckb-modules-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Load declared modules
+	modules, err := LoadDeclaredModules(tempDir, "", "test-state")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Should return nil when no file exists
+	if modules != nil {
+		t.Errorf("Expected nil modules, got %v", modules)
+	}
+}
+
+func TestGenerateStableModuleID(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"internal/api", "ckb:mod:"},
+		{"internal/query", "ckb:mod:"},
+		{"src/components", "ckb:mod:"},
+	}
+
+	for _, tt := range tests {
+		id := GenerateStableModuleID("", tt.path)
+		if id[:8] != tt.expected {
+			t.Errorf("Expected ID to start with '%s', got '%s'", tt.expected, id[:8])
+		}
+	}
+
+	// Verify same path produces same ID
+	id1 := GenerateStableModuleID("", "internal/api")
+	id2 := GenerateStableModuleID("", "internal/api")
+	if id1 != id2 {
+		t.Errorf("Expected stable ID, got %s != %s", id1, id2)
+	}
+
+	// Verify different paths produce different IDs
+	id3 := GenerateStableModuleID("", "internal/query")
+	if id1 == id3 {
+		t.Errorf("Expected different IDs for different paths, got %s == %s", id1, id3)
+	}
+}
+
+func TestParseModuleID(t *testing.T) {
+	tests := []struct {
+		input   string
+		prefix  string
+		hash    string
+		isValid bool
+	}{
+		{"ckb:mod:abc123", "ckb:mod", "abc123", true},
+		{"ckb:mod:1234567890abcdef", "ckb:mod", "1234567890abcdef", true},
+		{"invalid", "", "", false},
+		{"ckb:sym:abc123", "", "", false},
+		{"ckb:mod:", "", "", false},
+	}
+
+	for _, tt := range tests {
+		prefix, hash, isValid := ParseModuleID(tt.input)
+		if isValid != tt.isValid {
+			t.Errorf("ParseModuleID(%s): expected isValid=%v, got %v", tt.input, tt.isValid, isValid)
+		}
+		if isValid {
+			if prefix != tt.prefix {
+				t.Errorf("ParseModuleID(%s): expected prefix=%s, got %s", tt.input, tt.prefix, prefix)
+			}
+			if hash != tt.hash {
+				t.Errorf("ParseModuleID(%s): expected hash=%s, got %s", tt.input, tt.hash, hash)
+			}
+		}
+	}
+}
+
+func TestIsValidModuleID(t *testing.T) {
+	if !IsValidModuleID("ckb:mod:abc123") {
+		t.Error("Expected 'ckb:mod:abc123' to be valid")
+	}
+	if IsValidModuleID("invalid") {
+		t.Error("Expected 'invalid' to be invalid")
+	}
+	if IsValidModuleID("ckb:sym:abc123") {
+		t.Error("Expected 'ckb:sym:abc123' to be invalid for module ID")
+	}
+}
+
+func TestWriteAndReadModulesFile(t *testing.T) {
+	// Create a temp directory
+	tempDir, err := os.MkdirTemp("", "ckb-modules-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a modules file
+	original := &ModulesFile{
+		Version: 1,
+		Modules: []ModuleDeclaration{
+			{
+				Name:           "test",
+				Path:           "internal/test",
+				Responsibility: "Test module",
+				Owner:          "@test-team",
+				Tags:           []string{"test"},
+			},
+		},
+	}
+
+	filePath := filepath.Join(tempDir, "MODULES.toml")
+	if err := WriteModulesFile(filePath, original); err != nil {
+		t.Fatalf("Failed to write modules file: %v", err)
+	}
+
+	// Read it back
+	parsed, err := ParseModulesFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to parse written file: %v", err)
+	}
+
+	// Verify content
+	if parsed.Version != original.Version {
+		t.Errorf("Version mismatch: %d != %d", parsed.Version, original.Version)
+	}
+	if len(parsed.Modules) != len(original.Modules) {
+		t.Errorf("Module count mismatch: %d != %d", len(parsed.Modules), len(original.Modules))
+	}
+	if parsed.Modules[0].Name != original.Modules[0].Name {
+		t.Errorf("Name mismatch: %s != %s", parsed.Modules[0].Name, original.Modules[0].Name)
+	}
+}
+
+func TestExtractMetadataFromDeclarations(t *testing.T) {
+	// Create a temp directory
+	tempDir, err := os.MkdirTemp("", "ckb-modules-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a MODULES.toml file with metadata
+	modulesContent := `
+version = 1
+
+[[module]]
+id = "ckb:mod:custom123"
+name = "api"
+path = "internal/api"
+responsibility = "HTTP API handlers"
+owner = "@api-team"
+tags = ["core", "api"]
+
+[module.boundaries]
+exports = ["Handler"]
+`
+
+	modulesPath := filepath.Join(tempDir, "MODULES.toml")
+	if err := os.WriteFile(modulesPath, []byte(modulesContent), 0644); err != nil {
+		t.Fatalf("Failed to write MODULES.toml: %v", err)
+	}
+
+	// Extract metadata
+	metadata, err := ExtractMetadataFromDeclarations(modulesPath)
+	if err != nil {
+		t.Fatalf("Failed to extract metadata: %v", err)
+	}
+
+	// Verify metadata was extracted
+	if len(metadata) != 1 {
+		t.Errorf("Expected 1 metadata entry, got %d", len(metadata))
+	}
+
+	// Check for the custom ID entry
+	entry, ok := metadata["ckb:mod:custom123"]
+	if !ok {
+		t.Error("Expected metadata for 'ckb:mod:custom123'")
+	} else {
+		if entry.Responsibility != "HTTP API handlers" {
+			t.Errorf("Expected responsibility 'HTTP API handlers', got '%s'", entry.Responsibility)
+		}
+		if entry.Owner != "@api-team" {
+			t.Errorf("Expected owner '@api-team', got '%s'", entry.Owner)
+		}
+		if len(entry.Tags) != 2 {
+			t.Errorf("Expected 2 tags, got %d", len(entry.Tags))
+		}
+		if entry.Boundaries == nil {
+			t.Error("Expected boundaries to be set")
+		} else if len(entry.Boundaries.Exports) != 1 {
+			t.Errorf("Expected 1 export, got %d", len(entry.Boundaries.Exports))
+		}
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,6 +1,8 @@
 package paths
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,4 +80,195 @@ func FindRepoRoot() (string, error) {
 		return "", err
 	}
 	return cwd, nil
+}
+
+// v6.0 Persistence Paths
+// These functions manage the ~/.ckb/repos/ directory structure for persistent architectural data
+
+const (
+	// DefaultCKBHome is the default directory for CKB global data
+	DefaultCKBHome = ".ckb"
+
+	// ReposSubdir is the subdirectory for per-repo data
+	ReposSubdir = "repos"
+
+	// DecisionsSubdir is the subdirectory for ADR files
+	DecisionsSubdir = "decisions"
+
+	// CKBHomeEnvVar is the environment variable to override CKB home
+	CKBHomeEnvVar = "CKB_HOME"
+)
+
+// GetCKBHome returns the CKB home directory
+// Prefers $CKB_HOME environment variable, falls back to ~/.ckb
+func GetCKBHome() (string, error) {
+	// Check environment variable first
+	if envHome := os.Getenv(CKBHomeEnvVar); envHome != "" {
+		return envHome, nil
+	}
+
+	// Fall back to home directory
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(homeDir, DefaultCKBHome), nil
+}
+
+// ComputeRepoHash generates a stable hash for a repository path
+// This is used to create unique per-repo directories
+func ComputeRepoHash(repoRoot string) string {
+	// Resolve to absolute path
+	absPath, err := filepath.Abs(repoRoot)
+	if err != nil {
+		absPath = repoRoot
+	}
+
+	// Resolve symlinks if possible
+	resolved, err := filepath.EvalSymlinks(absPath)
+	if err == nil {
+		absPath = resolved
+	}
+
+	// Normalize path
+	normalized := filepath.ToSlash(absPath)
+
+	// Compute hash
+	hash := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(hash[:8]) // Use first 8 bytes for shorter hash
+}
+
+// GetRepoDataDir returns the data directory for a specific repository
+// Path: ~/.ckb/repos/<repo-hash>/
+func GetRepoDataDir(repoRoot string) (string, error) {
+	ckbHome, err := GetCKBHome()
+	if err != nil {
+		return "", err
+	}
+
+	repoHash := ComputeRepoHash(repoRoot)
+	return filepath.Join(ckbHome, ReposSubdir, repoHash), nil
+}
+
+// EnsureRepoDataDir creates the repo data directory if it doesn't exist
+// Returns the directory path
+func EnsureRepoDataDir(repoRoot string) (string, error) {
+	dataDir, err := GetRepoDataDir(repoRoot)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return "", err
+	}
+
+	return dataDir, nil
+}
+
+// GetDecisionsDir returns the ADR decisions directory for a repository
+// Path: ~/.ckb/repos/<repo-hash>/decisions/
+func GetDecisionsDir(repoRoot string) (string, error) {
+	dataDir, err := GetRepoDataDir(repoRoot)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dataDir, DecisionsSubdir), nil
+}
+
+// EnsureDecisionsDir creates the decisions directory if it doesn't exist
+// Returns the directory path
+func EnsureDecisionsDir(repoRoot string) (string, error) {
+	decisionsDir, err := GetDecisionsDir(repoRoot)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(decisionsDir, 0755); err != nil {
+		return "", err
+	}
+
+	return decisionsDir, nil
+}
+
+// GetRepoDatabasePath returns the path to the repo-specific database
+// Path: ~/.ckb/repos/<repo-hash>/ckb.db
+func GetRepoDatabasePath(repoRoot string) (string, error) {
+	dataDir, err := GetRepoDataDir(repoRoot)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dataDir, "ckb.db"), nil
+}
+
+// GetLocalDatabasePath returns the path to the local .ckb/ckb.db database
+// Path: <repoRoot>/.ckb/ckb.db
+func GetLocalDatabasePath(repoRoot string) string {
+	return filepath.Join(repoRoot, ".ckb", "ckb.db")
+}
+
+// GetSCIPIndexPath returns the path to the SCIP index file
+// Path: <repoRoot>/index.scip or configured path
+func GetSCIPIndexPath(repoRoot string, configuredPath string) string {
+	if configuredPath != "" {
+		if filepath.IsAbs(configuredPath) {
+			return configuredPath
+		}
+		return filepath.Join(repoRoot, configuredPath)
+	}
+	return filepath.Join(repoRoot, "index.scip")
+}
+
+// RepoInfo holds information about paths for a repository
+type RepoInfo struct {
+	// Root is the repository root directory
+	Root string
+
+	// Hash is the stable hash of the repository
+	Hash string
+
+	// LocalCKBDir is the .ckb directory in the repo root
+	LocalCKBDir string
+
+	// GlobalDataDir is the ~/.ckb/repos/<hash>/ directory
+	GlobalDataDir string
+
+	// LocalDatabasePath is the path to the local database
+	LocalDatabasePath string
+
+	// GlobalDatabasePath is the path to the global database
+	GlobalDatabasePath string
+
+	// DecisionsDir is the path to the ADR directory
+	DecisionsDir string
+}
+
+// GetRepoInfo returns all path information for a repository
+func GetRepoInfo(repoRoot string) (*RepoInfo, error) {
+	// Resolve to absolute path
+	absRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := ComputeRepoHash(absRoot)
+
+	ckbHome, err := GetCKBHome()
+	if err != nil {
+		return nil, err
+	}
+
+	globalDataDir := filepath.Join(ckbHome, ReposSubdir, hash)
+
+	return &RepoInfo{
+		Root:               absRoot,
+		Hash:               hash,
+		LocalCKBDir:        filepath.Join(absRoot, ".ckb"),
+		GlobalDataDir:      globalDataDir,
+		LocalDatabasePath:  filepath.Join(absRoot, ".ckb", "ckb.db"),
+		GlobalDatabasePath: filepath.Join(globalDataDir, "ckb.db"),
+		DecisionsDir:       filepath.Join(globalDataDir, DecisionsSubdir),
+	}, nil
 }

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,331 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetCKBHome(t *testing.T) {
+	// Test with environment variable
+	originalEnv := os.Getenv(CKBHomeEnvVar)
+	defer os.Setenv(CKBHomeEnvVar, originalEnv)
+
+	// Set custom home
+	customHome := "/custom/ckb/home"
+	os.Setenv(CKBHomeEnvVar, customHome)
+
+	home, err := GetCKBHome()
+	if err != nil {
+		t.Fatalf("GetCKBHome failed: %v", err)
+	}
+	if home != customHome {
+		t.Errorf("Expected %s, got %s", customHome, home)
+	}
+
+	// Test without environment variable
+	os.Unsetenv(CKBHomeEnvVar)
+
+	home, err = GetCKBHome()
+	if err != nil {
+		t.Fatalf("GetCKBHome failed: %v", err)
+	}
+
+	// Should end with .ckb
+	if !strings.HasSuffix(home, DefaultCKBHome) {
+		t.Errorf("Expected path to end with %s, got %s", DefaultCKBHome, home)
+	}
+}
+
+func TestComputeRepoHash(t *testing.T) {
+	// Same path should produce same hash
+	hash1 := ComputeRepoHash("/some/repo/path")
+	hash2 := ComputeRepoHash("/some/repo/path")
+	if hash1 != hash2 {
+		t.Errorf("Expected same hash for same path, got %s != %s", hash1, hash2)
+	}
+
+	// Different paths should produce different hashes
+	hash3 := ComputeRepoHash("/different/repo/path")
+	if hash1 == hash3 {
+		t.Errorf("Expected different hash for different path, got %s == %s", hash1, hash3)
+	}
+
+	// Hash should be a valid hex string
+	if len(hash1) != 16 { // 8 bytes = 16 hex chars
+		t.Errorf("Expected 16 character hash, got %d: %s", len(hash1), hash1)
+	}
+}
+
+func TestGetRepoDataDir(t *testing.T) {
+	// Use a temp directory as CKB home
+	tempDir, err := os.MkdirTemp("", "ckb-paths-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Set CKB_HOME
+	originalEnv := os.Getenv(CKBHomeEnvVar)
+	os.Setenv(CKBHomeEnvVar, tempDir)
+	defer os.Setenv(CKBHomeEnvVar, originalEnv)
+
+	repoRoot := "/my/repo"
+	dataDir, err := GetRepoDataDir(repoRoot)
+	if err != nil {
+		t.Fatalf("GetRepoDataDir failed: %v", err)
+	}
+
+	// Should be under CKB_HOME/repos/
+	expectedPrefix := filepath.Join(tempDir, ReposSubdir)
+	if !strings.HasPrefix(dataDir, expectedPrefix) {
+		t.Errorf("Expected path to start with %s, got %s", expectedPrefix, dataDir)
+	}
+}
+
+func TestEnsureRepoDataDir(t *testing.T) {
+	// Use a temp directory as CKB home
+	tempDir, err := os.MkdirTemp("", "ckb-paths-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Set CKB_HOME
+	originalEnv := os.Getenv(CKBHomeEnvVar)
+	os.Setenv(CKBHomeEnvVar, tempDir)
+	defer os.Setenv(CKBHomeEnvVar, originalEnv)
+
+	repoRoot := "/my/repo"
+	dataDir, err := EnsureRepoDataDir(repoRoot)
+	if err != nil {
+		t.Fatalf("EnsureRepoDataDir failed: %v", err)
+	}
+
+	// Verify directory was created
+	info, err := os.Stat(dataDir)
+	if err != nil {
+		t.Fatalf("Directory was not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("Expected a directory")
+	}
+}
+
+func TestGetDecisionsDir(t *testing.T) {
+	// Use a temp directory as CKB home
+	tempDir, err := os.MkdirTemp("", "ckb-paths-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Set CKB_HOME
+	originalEnv := os.Getenv(CKBHomeEnvVar)
+	os.Setenv(CKBHomeEnvVar, tempDir)
+	defer os.Setenv(CKBHomeEnvVar, originalEnv)
+
+	repoRoot := "/my/repo"
+	decisionsDir, err := GetDecisionsDir(repoRoot)
+	if err != nil {
+		t.Fatalf("GetDecisionsDir failed: %v", err)
+	}
+
+	// Should end with /decisions
+	if !strings.HasSuffix(decisionsDir, DecisionsSubdir) {
+		t.Errorf("Expected path to end with %s, got %s", DecisionsSubdir, decisionsDir)
+	}
+}
+
+func TestEnsureDecisionsDir(t *testing.T) {
+	// Use a temp directory as CKB home
+	tempDir, err := os.MkdirTemp("", "ckb-paths-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Set CKB_HOME
+	originalEnv := os.Getenv(CKBHomeEnvVar)
+	os.Setenv(CKBHomeEnvVar, tempDir)
+	defer os.Setenv(CKBHomeEnvVar, originalEnv)
+
+	repoRoot := "/my/repo"
+	decisionsDir, err := EnsureDecisionsDir(repoRoot)
+	if err != nil {
+		t.Fatalf("EnsureDecisionsDir failed: %v", err)
+	}
+
+	// Verify directory was created
+	info, err := os.Stat(decisionsDir)
+	if err != nil {
+		t.Fatalf("Directory was not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("Expected a directory")
+	}
+}
+
+func TestGetRepoDatabasePath(t *testing.T) {
+	// Use a temp directory as CKB home
+	tempDir, err := os.MkdirTemp("", "ckb-paths-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Set CKB_HOME
+	originalEnv := os.Getenv(CKBHomeEnvVar)
+	os.Setenv(CKBHomeEnvVar, tempDir)
+	defer os.Setenv(CKBHomeEnvVar, originalEnv)
+
+	repoRoot := "/my/repo"
+	dbPath, err := GetRepoDatabasePath(repoRoot)
+	if err != nil {
+		t.Fatalf("GetRepoDatabasePath failed: %v", err)
+	}
+
+	// Should end with ckb.db
+	if !strings.HasSuffix(dbPath, "ckb.db") {
+		t.Errorf("Expected path to end with ckb.db, got %s", dbPath)
+	}
+}
+
+func TestGetLocalDatabasePath(t *testing.T) {
+	repoRoot := "/my/repo"
+	dbPath := GetLocalDatabasePath(repoRoot)
+
+	expected := filepath.Join(repoRoot, ".ckb", "ckb.db")
+	if dbPath != expected {
+		t.Errorf("Expected %s, got %s", expected, dbPath)
+	}
+}
+
+func TestGetSCIPIndexPath(t *testing.T) {
+	repoRoot := "/my/repo"
+
+	// Default path
+	path := GetSCIPIndexPath(repoRoot, "")
+	expected := filepath.Join(repoRoot, "index.scip")
+	if path != expected {
+		t.Errorf("Expected %s, got %s", expected, path)
+	}
+
+	// Relative configured path
+	path = GetSCIPIndexPath(repoRoot, "custom/index.scip")
+	expected = filepath.Join(repoRoot, "custom/index.scip")
+	if path != expected {
+		t.Errorf("Expected %s, got %s", expected, path)
+	}
+
+	// Absolute configured path
+	path = GetSCIPIndexPath(repoRoot, "/absolute/index.scip")
+	if path != "/absolute/index.scip" {
+		t.Errorf("Expected /absolute/index.scip, got %s", path)
+	}
+}
+
+func TestGetRepoInfo(t *testing.T) {
+	// Use a temp directory as CKB home and repo
+	tempDir, err := os.MkdirTemp("", "ckb-paths-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Set CKB_HOME
+	originalEnv := os.Getenv(CKBHomeEnvVar)
+	os.Setenv(CKBHomeEnvVar, filepath.Join(tempDir, ".ckb-home"))
+	defer os.Setenv(CKBHomeEnvVar, originalEnv)
+
+	// Create a repo dir
+	repoDir := filepath.Join(tempDir, "my-repo")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("Failed to create repo dir: %v", err)
+	}
+
+	info, err := GetRepoInfo(repoDir)
+	if err != nil {
+		t.Fatalf("GetRepoInfo failed: %v", err)
+	}
+
+	// Verify all paths are set
+	if info.Root == "" {
+		t.Error("Root should be set")
+	}
+	if info.Hash == "" {
+		t.Error("Hash should be set")
+	}
+	if info.LocalCKBDir == "" {
+		t.Error("LocalCKBDir should be set")
+	}
+	if info.GlobalDataDir == "" {
+		t.Error("GlobalDataDir should be set")
+	}
+	if info.LocalDatabasePath == "" {
+		t.Error("LocalDatabasePath should be set")
+	}
+	if info.GlobalDatabasePath == "" {
+		t.Error("GlobalDatabasePath should be set")
+	}
+	if info.DecisionsDir == "" {
+		t.Error("DecisionsDir should be set")
+	}
+
+	// Verify paths are consistent
+	if !strings.HasSuffix(info.LocalCKBDir, ".ckb") {
+		t.Errorf("LocalCKBDir should end with .ckb, got %s", info.LocalCKBDir)
+	}
+	if !strings.HasSuffix(info.LocalDatabasePath, "ckb.db") {
+		t.Errorf("LocalDatabasePath should end with ckb.db, got %s", info.LocalDatabasePath)
+	}
+	if !strings.HasSuffix(info.GlobalDatabasePath, "ckb.db") {
+		t.Errorf("GlobalDatabasePath should end with ckb.db, got %s", info.GlobalDatabasePath)
+	}
+	if !strings.HasSuffix(info.DecisionsDir, DecisionsSubdir) {
+		t.Errorf("DecisionsDir should end with %s, got %s", DecisionsSubdir, info.DecisionsDir)
+	}
+}
+
+func TestCanonicalizePath(t *testing.T) {
+	// Create a temp directory for testing
+	tempDir, err := os.MkdirTemp("", "ckb-paths-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create test file
+	testFile := filepath.Join(tempDir, "subdir", "test.go")
+	if err := os.MkdirAll(filepath.Dir(testFile), 0755); err != nil {
+		t.Fatalf("Failed to create subdir: %v", err)
+	}
+	if err := os.WriteFile(testFile, []byte("package test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Test canonicalization
+	canonical, err := CanonicalizePath(testFile, tempDir)
+	if err != nil {
+		t.Fatalf("CanonicalizePath failed: %v", err)
+	}
+
+	expected := "subdir/test.go"
+	if canonical != expected {
+		t.Errorf("Expected %s, got %s", expected, canonical)
+	}
+}
+
+func TestNormalizePath(t *testing.T) {
+	// Test that forward slashes are preserved
+	result := NormalizePath("path/to/file")
+	expected := "path/to/file"
+	if result != expected {
+		t.Errorf("NormalizePath(path/to/file): expected %s, got %s", expected, result)
+	}
+
+	// Note: filepath.ToSlash only converts the OS-specific separator
+	// On Unix, backslashes are valid filename characters and won't be converted
+	// On Windows, backslashes would be converted to forward slashes
+}


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of v6.0 Architectural Memory - the core infrastructure for persistent architectural understanding that survives across sessions.

### Changes

- **Schema Migration (v1 → v2)**: Add 6 new tables for ownership, hotspots, responsibilities, decisions, and module renames. Extend modules table with boundaries and metadata fields.

- **MODULES.toml Parser**: Parse declared module boundaries with support for id, name, path, responsibility, boundaries, owner, and tags. Integrates into detection cascade as top priority.

- **Stable Module ID Generation**: Generate deterministic module IDs (`ckb:mod:<hash>`) that survive across sessions.

- **Persistence Paths**: Add `~/.ckb/repos/<repo-hash>/` structure for global persistent data with `CKB_HOME` environment variable override.

- **refreshArchitecture MCP Tool**: New heavy MCP tool for rebuilding the architectural model with scope options (all, modules, ownership, hotspots, responsibilities) and dry run support.

### Files Changed

| File | Description |
|------|-------------|
| `internal/storage/schema.go` | v2 schema with 6 new tables and FTS5 indexes |
| `internal/modules/declaration.go` | MODULES.toml parser and stable ID generation |
| `internal/modules/detection.go` | Integrate declared modules into detection cascade |
| `internal/paths/paths.go` | Persistence path functions |
| `internal/mcp/tools.go` | refreshArchitecture tool definition |
| `internal/mcp/tool_impls.go` | refreshArchitecture handler |
| `internal/query/architecture.go` | RefreshArchitecture engine method |

### Test plan

- [x] All existing tests pass
- [x] New MODULES.toml parser tests pass
- [x] New persistence path tests pass
- [x] Build succeeds
- [ ] Manual test: `./ckb mcp` and verify refreshArchitecture tool is available

### Next Steps (Phase 2-4)

- Implement CODEOWNERS parsing and git-blame ownership
- Add hotspot snapshot persistence and trend analysis
- Add responsibility extraction
- Add remaining v6.0 tools: getOwnership, getModuleResponsibilities, recordDecision, getDecisions, annotateModule

🤖 Generated with [Claude Code](https://claude.com/claude-code)