### PR TITLE
Add v6.0 Phase 3: Intelligence - hotspots and responsibilities

### DIFF
--- a/internal/hotspots/persistence.go
+++ b/internal/hotspots/persistence.go
@@ -1,0 +1,148 @@
+package hotspots
+
+import (
+	"time"
+)
+
+// HotspotSnapshot represents a point-in-time snapshot of hotspot metrics
+type HotspotSnapshot struct {
+	ID                   int64     `json:"id,omitempty"`
+	TargetID             string    `json:"targetId"`             // file path, module ID, or symbol ID
+	TargetType           string    `json:"targetType"`           // "file" | "module" | "symbol"
+	SnapshotDate         time.Time `json:"snapshotDate"`
+	ChurnCommits30d      int       `json:"churnCommits30d"`
+	ChurnCommits90d      int       `json:"churnCommits90d"`
+	ChurnAuthors30d      int       `json:"churnAuthors30d"`
+	ComplexityCyclomatic float64   `json:"complexityCyclomatic,omitempty"`
+	ComplexityCognitive  float64   `json:"complexityCognitive,omitempty"`
+	CouplingAfferent     int       `json:"couplingAfferent"`     // incoming dependencies
+	CouplingEfferent     int       `json:"couplingEfferent"`     // outgoing dependencies
+	CouplingInstability  float64   `json:"couplingInstability"`  // efferent / (afferent + efferent)
+	Score                float64   `json:"score"`                // composite hotspot score
+}
+
+// HotspotTrend represents the trend analysis for a hotspot
+type HotspotTrend struct {
+	Direction     string  `json:"direction"`     // "increasing" | "stable" | "decreasing"
+	Velocity      float64 `json:"velocity"`      // rate of change per day
+	Projection30d float64 `json:"projection30d"` // predicted score in 30 days
+	DataPoints    int     `json:"dataPoints"`    // number of snapshots used
+}
+
+// CalculateTrend computes a trend from a series of snapshots
+func CalculateTrend(snapshots []HotspotSnapshot) *HotspotTrend {
+	if len(snapshots) < 2 {
+		return &HotspotTrend{
+			Direction:     "stable",
+			Velocity:      0,
+			Projection30d: 0,
+			DataPoints:    len(snapshots),
+		}
+	}
+
+	// Sort by date (oldest first)
+	// Assume snapshots are already sorted
+
+	// Calculate linear regression for velocity
+	var sumX, sumY, sumXY, sumX2 float64
+	n := float64(len(snapshots))
+
+	baseDate := snapshots[0].SnapshotDate
+	for i, s := range snapshots {
+		x := float64(s.SnapshotDate.Sub(baseDate).Hours() / 24) // days since first snapshot
+		y := s.Score
+		sumX += x
+		sumY += y
+		sumXY += x * y
+		sumX2 += x * x
+		_ = i
+	}
+
+	// Linear regression: y = mx + b
+	// m = (n*sumXY - sumX*sumY) / (n*sumX2 - sumX*sumX)
+	denominator := n*sumX2 - sumX*sumX
+	var velocity float64
+	if denominator != 0 {
+		velocity = (n*sumXY - sumX*sumY) / denominator
+	}
+
+	// Determine direction
+	direction := "stable"
+	if velocity > 0.01 {
+		direction = "increasing"
+	} else if velocity < -0.01 {
+		direction = "decreasing"
+	}
+
+	// Project 30 days forward from latest snapshot
+	latestScore := snapshots[len(snapshots)-1].Score
+	projection30d := latestScore + velocity*30
+
+	// Don't project negative
+	if projection30d < 0 {
+		projection30d = 0
+	}
+
+	return &HotspotTrend{
+		Direction:     direction,
+		Velocity:      velocity,
+		Projection30d: projection30d,
+		DataPoints:    len(snapshots),
+	}
+}
+
+// CalculateInstability computes Martin's instability metric
+// Instability = Ce / (Ca + Ce) where Ce = efferent, Ca = afferent
+func CalculateInstability(afferent, efferent int) float64 {
+	total := afferent + efferent
+	if total == 0 {
+		return 0.5 // Neutral if no couplings
+	}
+	return float64(efferent) / float64(total)
+}
+
+// ComputeCompositeScore calculates the overall hotspot score
+// Weights: churn 40%, coupling 30%, complexity 30%
+func ComputeCompositeScore(churnScore, couplingScore, complexityScore float64) float64 {
+	return churnScore*0.4 + couplingScore*0.3 + complexityScore*0.3
+}
+
+// NormalizeChurnScore converts raw churn metrics to 0-1 score
+func NormalizeChurnScore(commits30d, commits90d, authors30d int) float64 {
+	// Higher commits and authors = higher score
+	// Use logarithmic scaling to prevent extreme outliers
+	commitScore := logNormalize(float64(commits30d), 10)      // 10 commits = 0.5
+	commitScore90 := logNormalize(float64(commits90d), 30)    // 30 commits = 0.5
+	authorScore := logNormalize(float64(authors30d), 3)       // 3 authors = 0.5
+
+	// Weight recent commits more heavily
+	return commitScore*0.5 + commitScore90*0.2 + authorScore*0.3
+}
+
+// logNormalize normalizes a value using logarithmic scaling
+// Returns 0.5 when value equals midpoint
+func logNormalize(value, midpoint float64) float64 {
+	if value <= 0 {
+		return 0
+	}
+	// Use sigmoid-like curve: 1 / (1 + e^(-k*(x-m)))
+	// Simplified: value / (value + midpoint)
+	return value / (value + midpoint)
+}
+
+// NormalizeCouplingScore converts coupling metrics to 0-1 score
+func NormalizeCouplingScore(afferent, efferent int) float64 {
+	total := afferent + efferent
+	if total == 0 {
+		return 0
+	}
+	// High coupling = high score
+	return logNormalize(float64(total), 10) // 10 total dependencies = 0.5
+}
+
+// NormalizeComplexityScore converts complexity metrics to 0-1 score
+func NormalizeComplexityScore(cyclomatic, cognitive float64) float64 {
+	cyclomaticScore := logNormalize(cyclomatic, 10)  // 10 cyclomatic = 0.5
+	cognitiveScore := logNormalize(cognitive, 15)    // 15 cognitive = 0.5
+	return (cyclomaticScore + cognitiveScore) / 2
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -466,6 +466,29 @@ func (s *MCPServer) GetToolDefinitions() []Tool {
 				"required": []string{"path"},
 			},
 		},
+		{
+			Name:        "getModuleResponsibilities",
+			Description: "Get responsibilities for modules. Returns what each module does, its capabilities, and how confident we are in this assessment. Extracted from README files, doc comments, and code analysis.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"moduleId": map[string]interface{}{
+						"type":        "string",
+						"description": "Specific module ID to get responsibilities for. Omit to get all modules.",
+					},
+					"includeFiles": map[string]interface{}{
+						"type":        "boolean",
+						"default":     false,
+						"description": "Whether to include file-level responsibilities",
+					},
+					"limit": map[string]interface{}{
+						"type":        "integer",
+						"default":     20,
+						"description": "Maximum number of modules to return",
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -493,4 +516,5 @@ func (s *MCPServer) RegisterTools() {
 	// v6.0 Architectural Memory tools
 	s.tools["refreshArchitecture"] = s.toolRefreshArchitecture
 	s.tools["getOwnership"] = s.toolGetOwnership
+	s.tools["getModuleResponsibilities"] = s.toolGetModuleResponsibilities
 }

--- a/internal/query/responsibilities.go
+++ b/internal/query/responsibilities.go
@@ -1,0 +1,257 @@
+package query
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"ckb/internal/output"
+	"ckb/internal/responsibilities"
+)
+
+// GetModuleResponsibilitiesOptions controls getModuleResponsibilities behavior.
+type GetModuleResponsibilitiesOptions struct {
+	ModuleId     string // Specific module, or empty for all
+	IncludeFiles bool   // Include file-level responsibilities
+	Limit        int    // Max modules to return
+}
+
+// ModuleResponsibility represents a module's responsibility info.
+type ModuleResponsibility struct {
+	ModuleId     string                `json:"moduleId"`
+	Name         string                `json:"name"`
+	Path         string                `json:"path"`
+	Summary      string                `json:"summary"`
+	Capabilities []string              `json:"capabilities,omitempty"`
+	Source       string                `json:"source"` // "declared" | "inferred"
+	Confidence   float64               `json:"confidence"`
+	Files        []FileResponsibility  `json:"files,omitempty"`
+}
+
+// FileResponsibility represents a file's responsibility info.
+type FileResponsibility struct {
+	Path       string  `json:"path"`
+	Summary    string  `json:"summary"`
+	Confidence float64 `json:"confidence"`
+}
+
+// GetModuleResponsibilitiesResponse is the response for getModuleResponsibilities.
+type GetModuleResponsibilitiesResponse struct {
+	CkbVersion      string                   `json:"ckbVersion"`
+	SchemaVersion   string                   `json:"schemaVersion"`
+	Tool            string                   `json:"tool"`
+	Modules         []ModuleResponsibility   `json:"modules"`
+	TotalCount      int                      `json:"totalCount"`
+	Confidence      float64                  `json:"confidence"`
+	ConfidenceBasis []ConfidenceBasisItem    `json:"confidenceBasis"`
+	Limitations     []string                 `json:"limitations,omitempty"`
+	Provenance      *Provenance              `json:"provenance,omitempty"`
+	Drilldowns      []output.Drilldown       `json:"drilldowns,omitempty"`
+}
+
+// GetModuleResponsibilities returns responsibilities for modules.
+func (e *Engine) GetModuleResponsibilities(ctx context.Context, opts GetModuleResponsibilitiesOptions) (*GetModuleResponsibilitiesResponse, error) {
+	startTime := time.Now()
+
+	if opts.Limit <= 0 {
+		opts.Limit = 20
+	}
+
+	var confidenceBasis []ConfidenceBasisItem
+	var limitations []string
+	var moduleResponsibilities []ModuleResponsibility
+
+	// Get repo state
+	repoState, err := e.GetRepoState(ctx, "head")
+	if err != nil {
+		return nil, err
+	}
+
+	// Create responsibility extractor
+	extractor := responsibilities.NewExtractor(e.repoRoot)
+
+	// Get modules from architecture
+	archOpts := GetArchitectureOptions{Depth: 2}
+	archResp, err := e.GetArchitecture(ctx, archOpts)
+	if err != nil {
+		limitations = append(limitations, "Could not get architecture: "+err.Error())
+	}
+
+	confidenceBasis = append(confidenceBasis, ConfidenceBasisItem{
+		Backend: "responsibility-extractor",
+		Status:  "available",
+	})
+
+	// If specific module requested, filter
+	if opts.ModuleId != "" && archResp != nil {
+		for _, m := range archResp.Modules {
+			if m.ModuleId == opts.ModuleId || m.Path == opts.ModuleId {
+				resp, respErr := extractor.ExtractFromModule(m.Path)
+				if respErr != nil {
+					limitations = append(limitations, "Failed to extract from "+m.Path+": "+respErr.Error())
+					continue
+				}
+
+				modResp := ModuleResponsibility{
+					ModuleId:     m.ModuleId,
+					Name:         m.Name,
+					Path:         m.Path,
+					Summary:      resp.Summary,
+					Capabilities: resp.Capabilities,
+					Source:       resp.Source,
+					Confidence:   resp.Confidence,
+				}
+
+				// Include file responsibilities if requested
+				if opts.IncludeFiles {
+					modResp.Files = e.extractFileResponsibilities(extractor, m.Path)
+				}
+
+				moduleResponsibilities = append(moduleResponsibilities, modResp)
+				break
+			}
+		}
+	} else if archResp != nil {
+		// Get all modules
+		for i, m := range archResp.Modules {
+			if i >= opts.Limit {
+				break
+			}
+
+			resp, respErr := extractor.ExtractFromModule(m.Path)
+			if respErr != nil {
+				limitations = append(limitations, "Failed to extract from "+m.Path+": "+respErr.Error())
+				continue
+			}
+
+			modResp := ModuleResponsibility{
+				ModuleId:     m.ModuleId,
+				Name:         m.Name,
+				Path:         m.Path,
+				Summary:      resp.Summary,
+				Capabilities: resp.Capabilities,
+				Source:       resp.Source,
+				Confidence:   resp.Confidence,
+			}
+
+			// Include file responsibilities if requested
+			if opts.IncludeFiles {
+				modResp.Files = e.extractFileResponsibilities(extractor, m.Path)
+			}
+
+			moduleResponsibilities = append(moduleResponsibilities, modResp)
+		}
+	}
+
+	// Compute overall confidence
+	confidence := 0.69 // Base confidence for inferred
+	if len(moduleResponsibilities) > 0 {
+		var totalConf float64
+		for _, m := range moduleResponsibilities {
+			totalConf += m.Confidence
+		}
+		confidence = totalConf / float64(len(moduleResponsibilities))
+	}
+
+	// Build completeness
+	completeness := CompletenessInfo{
+		Score:  1.0,
+		Reason: "responsibilities-extracted",
+	}
+	if len(limitations) > 0 {
+		completeness.Score = 0.7
+		completeness.Reason = "partial-extraction"
+	}
+
+	// Build provenance
+	provenance := e.buildProvenance(repoState, "head", startTime, nil, completeness)
+
+	// Generate drilldowns
+	var drilldowns []output.Drilldown
+	if len(moduleResponsibilities) > 0 {
+		drilldowns = append(drilldowns, output.Drilldown{
+			Label:          "Get architecture",
+			Query:          "getArchitecture",
+			RelevanceScore: 0.8,
+		})
+		drilldowns = append(drilldowns, output.Drilldown{
+			Label:          "Get ownership",
+			Query:          "getOwnership for " + moduleResponsibilities[0].Path,
+			RelevanceScore: 0.7,
+		})
+	}
+
+	return &GetModuleResponsibilitiesResponse{
+		CkbVersion:      "6.0",
+		SchemaVersion:   "6.0",
+		Tool:            "getModuleResponsibilities",
+		Modules:         moduleResponsibilities,
+		TotalCount:      len(moduleResponsibilities),
+		Confidence:      confidence,
+		ConfidenceBasis: confidenceBasis,
+		Limitations:     limitations,
+		Provenance:      provenance,
+		Drilldowns:      drilldowns,
+	}, nil
+}
+
+// extractFileResponsibilities extracts responsibilities for files in a module
+func (e *Engine) extractFileResponsibilities(extractor *responsibilities.Extractor, modulePath string) []FileResponsibility {
+	var files []FileResponsibility
+
+	fullPath := filepath.Join(e.repoRoot, modulePath)
+	entries, err := os.ReadDir(fullPath)
+	if err != nil {
+		return files
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		// Only process source files
+		name := entry.Name()
+		if !isSourceFile(name) {
+			continue
+		}
+
+		filePath := filepath.Join(modulePath, name)
+		resp, err := extractor.ExtractFromFile(filePath)
+		if err != nil {
+			continue
+		}
+
+		files = append(files, FileResponsibility{
+			Path:       filePath,
+			Summary:    resp.Summary,
+			Confidence: resp.Confidence,
+		})
+
+		// Limit files per module
+		if len(files) >= 10 {
+			break
+		}
+	}
+
+	return files
+}
+
+// isSourceFile checks if a file is a source code file
+func isSourceFile(name string) bool {
+	sourceExtensions := map[string]bool{
+		".go":   true,
+		".ts":   true,
+		".tsx":  true,
+		".js":   true,
+		".jsx":  true,
+		".py":   true,
+		".rs":   true,
+		".java": true,
+		".kt":   true,
+		".dart": true,
+	}
+	ext := filepath.Ext(name)
+	return sourceExtensions[ext]
+}

--- a/internal/responsibilities/extractor.go
+++ b/internal/responsibilities/extractor.go
@@ -1,0 +1,414 @@
+package responsibilities
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Responsibility represents extracted responsibility information
+type Responsibility struct {
+	TargetID     string    `json:"targetId"`
+	TargetType   string    `json:"targetType"` // "module" | "file" | "symbol"
+	Summary      string    `json:"summary"`
+	Capabilities []string  `json:"capabilities"`
+	Source       string    `json:"source"` // "declared" | "inferred"
+	Confidence   float64   `json:"confidence"`
+	UpdatedAt    time.Time `json:"updatedAt"`
+}
+
+// Extractor extracts responsibilities from source code and documentation
+type Extractor struct {
+	repoRoot string
+}
+
+// NewExtractor creates a new responsibility extractor
+func NewExtractor(repoRoot string) *Extractor {
+	return &Extractor{repoRoot: repoRoot}
+}
+
+// ExtractFromModule extracts responsibility from a module directory
+func (e *Extractor) ExtractFromModule(modulePath string) (*Responsibility, error) {
+	fullPath := filepath.Join(e.repoRoot, modulePath)
+
+	// Try README first (highest confidence)
+	readmeSummary, readmeCaps := e.extractFromReadme(fullPath)
+	if readmeSummary != "" {
+		return &Responsibility{
+			TargetID:     modulePath,
+			TargetType:   "module",
+			Summary:      readmeSummary,
+			Capabilities: readmeCaps,
+			Source:       "declared",
+			Confidence:   0.89,
+			UpdatedAt:    time.Now(),
+		}, nil
+	}
+
+	// Try package doc comment (Go-specific)
+	docSummary, docCaps := e.extractFromGoPackageDoc(fullPath)
+	if docSummary != "" {
+		return &Responsibility{
+			TargetID:     modulePath,
+			TargetType:   "module",
+			Summary:      docSummary,
+			Capabilities: docCaps,
+			Source:       "declared",
+			Confidence:   0.89,
+			UpdatedAt:    time.Now(),
+		}, nil
+	}
+
+	// Fall back to inferring from exports
+	inferredSummary, inferredCaps := e.inferFromExports(fullPath)
+	if inferredSummary != "" {
+		return &Responsibility{
+			TargetID:     modulePath,
+			TargetType:   "module",
+			Summary:      inferredSummary,
+			Capabilities: inferredCaps,
+			Source:       "inferred",
+			Confidence:   0.59,
+			UpdatedAt:    time.Now(),
+		}, nil
+	}
+
+	// Heuristic-only fallback
+	return &Responsibility{
+		TargetID:     modulePath,
+		TargetType:   "module",
+		Summary:      "Module at " + modulePath,
+		Capabilities: []string{},
+		Source:       "inferred",
+		Confidence:   0.39,
+		UpdatedAt:    time.Now(),
+	}, nil
+}
+
+// ExtractFromFile extracts responsibility from a file
+func (e *Extractor) ExtractFromFile(filePath string) (*Responsibility, error) {
+	fullPath := filepath.Join(e.repoRoot, filePath)
+
+	// Try file-level doc comment
+	docSummary := e.extractFileDocComment(fullPath)
+	if docSummary != "" {
+		return &Responsibility{
+			TargetID:     filePath,
+			TargetType:   "file",
+			Summary:      docSummary,
+			Capabilities: []string{},
+			Source:       "declared",
+			Confidence:   0.89,
+			UpdatedAt:    time.Now(),
+		}, nil
+	}
+
+	// Infer from file name and contents
+	inferredSummary := e.inferFromFileName(filePath)
+	return &Responsibility{
+		TargetID:     filePath,
+		TargetType:   "file",
+		Summary:      inferredSummary,
+		Capabilities: []string{},
+		Source:       "inferred",
+		Confidence:   0.49,
+		UpdatedAt:    time.Now(),
+	}, nil
+}
+
+// extractFromReadme extracts summary from README.md
+func (e *Extractor) extractFromReadme(dirPath string) (string, []string) {
+	readmeNames := []string{"README.md", "README", "readme.md"}
+
+	for _, name := range readmeNames {
+		readmePath := filepath.Join(dirPath, name)
+		if _, err := os.Stat(readmePath); err == nil {
+			return e.parseReadme(readmePath)
+		}
+	}
+
+	return "", nil
+}
+
+// parseReadme extracts the first paragraph and any bullet points as capabilities
+func (e *Extractor) parseReadme(path string) (string, []string) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", nil
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var summary string
+	var capabilities []string
+	inFirstParagraph := false
+	paragraphLines := []string{}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip title lines (# heading)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Skip badges and empty lines at start
+		if strings.TrimSpace(line) == "" {
+			if inFirstParagraph {
+				// End of first paragraph
+				break
+			}
+			continue
+		}
+
+		// Skip badge lines (usually start with ![)
+		if strings.HasPrefix(strings.TrimSpace(line), "![") {
+			continue
+		}
+
+		// Collect bullet points as capabilities
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+			cap := strings.TrimPrefix(strings.TrimPrefix(trimmed, "- "), "* ")
+			if len(cap) > 0 && len(cap) < 100 {
+				capabilities = append(capabilities, cap)
+			}
+			continue
+		}
+
+		// First real content line starts the paragraph
+		inFirstParagraph = true
+		paragraphLines = append(paragraphLines, line)
+	}
+
+	if len(paragraphLines) > 0 {
+		summary = strings.Join(paragraphLines, " ")
+		// Trim to reasonable length
+		if len(summary) > 200 {
+			summary = summary[:197] + "..."
+		}
+	}
+
+	return summary, capabilities
+}
+
+// extractFromGoPackageDoc extracts the package doc comment from Go files
+func (e *Extractor) extractFromGoPackageDoc(dirPath string) (string, []string) {
+	// Look for doc.go first, then any .go file
+	docGoPath := filepath.Join(dirPath, "doc.go")
+	if _, err := os.Stat(docGoPath); err == nil {
+		return e.parseGoDocComment(docGoPath)
+	}
+
+	// Try any .go file
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return "", nil
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".go") && !strings.HasSuffix(entry.Name(), "_test.go") {
+			goPath := filepath.Join(dirPath, entry.Name())
+			summary, caps := e.parseGoDocComment(goPath)
+			if summary != "" {
+				return summary, caps
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// parseGoDocComment extracts the package-level doc comment
+func (e *Extractor) parseGoDocComment(path string) (string, []string) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", nil
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var docLines []string
+	inDocComment := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		// Start of package declaration ends doc comment
+		if strings.HasPrefix(trimmed, "package ") {
+			break
+		}
+
+		// Doc comment line
+		if strings.HasPrefix(trimmed, "//") {
+			inDocComment = true
+			// Remove // prefix and leading space
+			docLine := strings.TrimPrefix(trimmed, "//")
+			docLine = strings.TrimPrefix(docLine, " ")
+			docLines = append(docLines, docLine)
+		} else if strings.TrimSpace(line) == "" && inDocComment {
+			// Empty line in comment section
+			docLines = append(docLines, "")
+		} else if inDocComment {
+			// Non-comment, non-empty line before package - reset
+			docLines = nil
+			inDocComment = false
+		}
+	}
+
+	if len(docLines) == 0 {
+		return "", nil
+	}
+
+	// First line is usually "Package X does Y"
+	summary := strings.Join(docLines, " ")
+	summary = strings.TrimSpace(summary)
+
+	// Extract "Package X" pattern
+	packagePattern := regexp.MustCompile(`^Package\s+\w+\s+(.+)`)
+	if matches := packagePattern.FindStringSubmatch(summary); len(matches) > 1 {
+		summary = strings.TrimSuffix(matches[1], ".")
+	}
+
+	if len(summary) > 200 {
+		summary = summary[:197] + "..."
+	}
+
+	return summary, nil
+}
+
+// extractFileDocComment extracts the first doc comment from a file
+func (e *Extractor) extractFileDocComment(path string) string {
+	file, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var docLines []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		// Skip empty lines at start
+		if trimmed == "" {
+			continue
+		}
+
+		// Comment line
+		if strings.HasPrefix(trimmed, "//") {
+			docLine := strings.TrimPrefix(trimmed, "//")
+			docLine = strings.TrimPrefix(docLine, " ")
+			docLines = append(docLines, docLine)
+		} else {
+			// Non-comment line - stop
+			break
+		}
+	}
+
+	if len(docLines) == 0 {
+		return ""
+	}
+
+	summary := strings.Join(docLines, " ")
+	if len(summary) > 200 {
+		summary = summary[:197] + "..."
+	}
+
+	return summary
+}
+
+// inferFromExports creates a summary from exported symbols
+func (e *Extractor) inferFromExports(dirPath string) (string, []string) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return "", nil
+	}
+
+	var exports []string
+	exportPattern := regexp.MustCompile(`^(func|type|var|const)\s+([A-Z]\w*)`)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+
+		filePath := filepath.Join(dirPath, entry.Name())
+		file, err := os.Open(filePath)
+		if err != nil {
+			continue
+		}
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if matches := exportPattern.FindStringSubmatch(line); len(matches) > 2 {
+				exports = append(exports, matches[2])
+				if len(exports) >= 10 {
+					break
+				}
+			}
+		}
+		file.Close()
+
+		if len(exports) >= 10 {
+			break
+		}
+	}
+
+	if len(exports) == 0 {
+		return "", nil
+	}
+
+	// Create summary from exports
+	summary := "Provides " + strings.Join(exports[:min(5, len(exports))], ", ")
+	if len(exports) > 5 {
+		summary += fmt.Sprintf(" and %d more", len(exports)-5)
+	}
+
+	return summary, exports
+}
+
+// inferFromFileName creates a summary from the file name
+func (e *Extractor) inferFromFileName(filePath string) string {
+	base := filepath.Base(filePath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+
+	// Convert snake_case or camelCase to words
+	name = regexp.MustCompile(`[_-]`).ReplaceAllString(name, " ")
+	name = regexp.MustCompile(`([a-z])([A-Z])`).ReplaceAllString(name, "$1 $2")
+	name = strings.ToLower(name)
+
+	// Determine role from name patterns
+	switch {
+	case strings.Contains(name, "test"):
+		return "Contains tests"
+	case strings.Contains(name, "config"):
+		return "Configuration for " + name
+	case strings.Contains(name, "util") || strings.Contains(name, "helper"):
+		return "Utility functions"
+	case strings.Contains(name, "handler"):
+		return "Request handler"
+	case strings.Contains(name, "service"):
+		return "Service implementation"
+	case strings.Contains(name, "model") || strings.Contains(name, "types"):
+		return "Data types and models"
+	default:
+		return "Implements " + name + " functionality"
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary

- **Hotspot Persistence**: Time-series snapshot storage with trend calculation using linear regression
- **Responsibility Extraction**: Extract module/file responsibilities from README, doc comments, and exports
- **Storage Repositories**: HotspotRepository and ResponsibilityRepository with full CRUD operations
- **getModuleResponsibilities MCP Tool**: Query what modules do with confidence scores

## New Files

| File | Purpose |
|------|---------|
| `internal/hotspots/persistence.go` | Hotspot snapshot types and trend calculation |
| `internal/responsibilities/extractor.go` | Responsibility extraction from code and docs |
| `internal/query/responsibilities.go` | GetModuleResponsibilities query engine |

## Key Features

### Hotspot Trends
- Linear regression-based velocity calculation
- Score normalization (churn 40%, coupling 30%, complexity 30%)
- Martin's instability metric: `Ce / (Ca + Ce)`
- Direction: "increasing", "stable", "decreasing"

### Responsibility Extraction
- **README.md**: First paragraph as summary, bullet points as capabilities
- **Doc comments**: `// Package X does Y` extraction
- **Export inference**: `Provides X, Y, Z` from exported symbols
- **Confidence levels**: declared=0.89, inferred=0.59, heuristic=0.39

## Test plan

- [x] Storage tests pass
- [x] Query engine tests pass
- [x] MCP tests pass
- [x] Build succeeds
- [ ] Manual test: `getModuleResponsibilities` on a module with README
- [ ] Manual test: `getModuleResponsibilities` on a module without README

🤖 Generated with [Claude Code](https://claude.com/claude-code)