### PR TITLE
feat: Add Phase 4 - Architectural Decision Records (ADRs)

### DIFF
--- a/internal/decisions/parser.go
+++ b/internal/decisions/parser.go
@@ -1,0 +1,319 @@
+package decisions
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Parser parses ADR markdown files
+type Parser struct {
+	repoRoot string
+}
+
+// NewParser creates a new ADR parser
+func NewParser(repoRoot string) *Parser {
+	return &Parser{repoRoot: repoRoot}
+}
+
+// FindADRDirectories returns directories that may contain ADRs
+func (p *Parser) FindADRDirectories() []string {
+	candidates := []string{
+		"docs/decisions",
+		"docs/adr",
+		"adr",
+		"decisions",
+		"doc/adr",
+		"doc/decisions",
+	}
+
+	var found []string
+	for _, dir := range candidates {
+		fullPath := filepath.Join(p.repoRoot, dir)
+		if info, err := os.Stat(fullPath); err == nil && info.IsDir() {
+			found = append(found, dir)
+		}
+	}
+
+	return found
+}
+
+// ParseDirectory parses all ADRs in a directory
+func (p *Parser) ParseDirectory(dirPath string) ([]*ArchitecturalDecision, error) {
+	fullPath := filepath.Join(p.repoRoot, dirPath)
+	entries, err := os.ReadDir(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	var adrs []*ArchitecturalDecision
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+
+		// Check if filename matches ADR pattern
+		if !isADRFile(name) {
+			continue
+		}
+
+		filePath := filepath.Join(dirPath, name)
+		adr, err := p.ParseFile(filePath)
+		if err != nil {
+			// Log but continue
+			continue
+		}
+
+		adrs = append(adrs, adr)
+	}
+
+	return adrs, nil
+}
+
+// ParseFile parses a single ADR markdown file
+func (p *Parser) ParseFile(relPath string) (*ArchitecturalDecision, error) {
+	fullPath := filepath.Join(p.repoRoot, relPath)
+	file, err := os.Open(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	adr := &ArchitecturalDecision{
+		FilePath: relPath,
+	}
+
+	scanner := bufio.NewScanner(file)
+	var currentSection string
+	var sectionContent []string
+
+	// Patterns for extracting metadata
+	titlePattern := regexp.MustCompile(`^#\s*(ADR[-\s]?\d+)[:\s]*(.*)$`)
+	statusPattern := regexp.MustCompile(`(?i)\*?\*?Status:?\*?\*?\s*(.+)`)
+	datePattern := regexp.MustCompile(`(?i)\*?\*?Date:?\*?\*?\s*(.+)`)
+	authorPattern := regexp.MustCompile(`(?i)\*?\*?Author:?\*?\*?\s*(.+)`)
+	supersededPattern := regexp.MustCompile(`(?i)\*?\*?Superseded\s*by:?\*?\*?\s*(.+)`)
+	sectionPattern := regexp.MustCompile(`^##\s*(.+)$`)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Parse title line
+		if matches := titlePattern.FindStringSubmatch(line); len(matches) > 2 {
+			adr.ID = normalizeADRID(matches[1])
+			adr.Title = strings.TrimSpace(matches[2])
+			continue
+		}
+
+		// Parse status
+		if matches := statusPattern.FindStringSubmatch(line); len(matches) > 1 {
+			adr.Status = strings.ToLower(strings.TrimSpace(matches[1]))
+			continue
+		}
+
+		// Parse date
+		if matches := datePattern.FindStringSubmatch(line); len(matches) > 1 {
+			dateStr := strings.TrimSpace(matches[1])
+			if t, err := parseDate(dateStr); err == nil {
+				adr.Date = t
+			}
+			continue
+		}
+
+		// Parse author
+		if matches := authorPattern.FindStringSubmatch(line); len(matches) > 1 {
+			adr.Author = strings.TrimSpace(matches[1])
+			continue
+		}
+
+		// Parse superseded by
+		if matches := supersededPattern.FindStringSubmatch(line); len(matches) > 1 {
+			adr.SupersededBy = strings.TrimSpace(matches[1])
+			continue
+		}
+
+		// Section header
+		if matches := sectionPattern.FindStringSubmatch(line); len(matches) > 1 {
+			// Save previous section
+			if currentSection != "" {
+				saveSection(adr, currentSection, sectionContent)
+			}
+			currentSection = strings.ToLower(strings.TrimSpace(matches[1]))
+			sectionContent = nil
+			continue
+		}
+
+		// Content line
+		if currentSection != "" {
+			sectionContent = append(sectionContent, line)
+		}
+	}
+
+	// Save last section
+	if currentSection != "" {
+		saveSection(adr, currentSection, sectionContent)
+	}
+
+	// Extract ID from filename if not found in content
+	if adr.ID == "" {
+		adr.ID = extractIDFromFilename(relPath)
+	}
+
+	// Default status
+	if adr.Status == "" {
+		adr.Status = string(StatusProposed)
+	}
+
+	// Default date to file modification time
+	if adr.Date.IsZero() {
+		if info, err := os.Stat(fullPath); err == nil {
+			adr.Date = info.ModTime()
+		} else {
+			adr.Date = time.Now()
+		}
+	}
+
+	return adr, scanner.Err()
+}
+
+// saveSection saves parsed section content to the ADR
+func saveSection(adr *ArchitecturalDecision, section string, content []string) {
+	text := strings.TrimSpace(strings.Join(content, "\n"))
+
+	switch {
+	case strings.Contains(section, "context"):
+		adr.Context = text
+	case strings.Contains(section, "decision"):
+		adr.Decision = text
+	case strings.Contains(section, "consequence"):
+		adr.Consequences = extractBulletPoints(content)
+	case strings.Contains(section, "affected") || strings.Contains(section, "module"):
+		adr.AffectedModules = extractBulletPoints(content)
+	case strings.Contains(section, "alternative"):
+		adr.Alternatives = extractBulletPoints(content)
+	}
+}
+
+// extractBulletPoints extracts bullet point items from lines
+func extractBulletPoints(lines []string) []string {
+	var items []string
+	bulletPattern := regexp.MustCompile(`^\s*[-*]\s*(.+)$`)
+
+	for _, line := range lines {
+		if matches := bulletPattern.FindStringSubmatch(line); len(matches) > 1 {
+			item := strings.TrimSpace(matches[1])
+			if item != "" {
+				items = append(items, item)
+			}
+		}
+	}
+
+	return items
+}
+
+// isADRFile checks if a filename looks like an ADR
+func isADRFile(name string) bool {
+	lower := strings.ToLower(name)
+	// Match patterns like: ADR-001.md, 001-some-title.md, adr-001-title.md
+	adrPatterns := []string{
+		`^adr[-_]?\d+`,
+		`^\d{3,4}[-_]`,
+	}
+
+	for _, pattern := range adrPatterns {
+		if matched, _ := regexp.MatchString(pattern, lower); matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// normalizeADRID normalizes an ADR ID to "ADR-NNN" format
+func normalizeADRID(id string) string {
+	// Extract number
+	numPattern := regexp.MustCompile(`\d+`)
+	numStr := numPattern.FindString(id)
+	if numStr == "" {
+		return id
+	}
+
+	// Pad to 3 digits
+	var num int
+	fmt.Sscanf(numStr, "%d", &num)
+	return fmt.Sprintf("ADR-%03d", num)
+}
+
+// extractIDFromFilename extracts an ADR ID from a filename
+func extractIDFromFilename(path string) string {
+	base := filepath.Base(path)
+	base = strings.TrimSuffix(base, ".md")
+
+	// Try to find ADR number
+	numPattern := regexp.MustCompile(`\d{3,4}`)
+	numStr := numPattern.FindString(base)
+	if numStr != "" {
+		var num int
+		fmt.Sscanf(numStr, "%d", &num)
+		return fmt.Sprintf("ADR-%03d", num)
+	}
+
+	return base
+}
+
+// parseDate attempts to parse various date formats
+func parseDate(s string) (time.Time, error) {
+	formats := []string{
+		"2006-01-02",
+		"January 2, 2006",
+		"Jan 2, 2006",
+		"2006/01/02",
+		"02-01-2006",
+		"02/01/2006",
+	}
+
+	s = strings.TrimSpace(s)
+	for _, format := range formats {
+		if t, err := time.Parse(format, s); err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("unable to parse date: %s", s)
+}
+
+// GetNextADRNumber finds the next available ADR number
+func (p *Parser) GetNextADRNumber() (int, error) {
+	dirs := p.FindADRDirectories()
+
+	maxNum := 0
+	numPattern := regexp.MustCompile(`ADR-(\d+)`)
+
+	for _, dir := range dirs {
+		adrs, err := p.ParseDirectory(dir)
+		if err != nil {
+			continue
+		}
+
+		for _, adr := range adrs {
+			if matches := numPattern.FindStringSubmatch(adr.ID); len(matches) > 1 {
+				var num int
+				fmt.Sscanf(matches[1], "%d", &num)
+				if num > maxNum {
+					maxNum = num
+				}
+			}
+		}
+	}
+
+	return maxNum + 1, nil
+}

--- a/internal/decisions/types.go
+++ b/internal/decisions/types.go
@@ -1,0 +1,75 @@
+package decisions
+
+import (
+	"time"
+)
+
+// ArchitecturalDecision represents an ADR (Architectural Decision Record)
+type ArchitecturalDecision struct {
+	ID              string    `json:"id"`              // "ADR-001" style
+	Title           string    `json:"title"`
+	Status          string    `json:"status"`          // "proposed" | "accepted" | "deprecated" | "superseded"
+	Context         string    `json:"context"`
+	Decision        string    `json:"decision"`
+	Consequences    []string  `json:"consequences"`
+	AffectedModules []string  `json:"affectedModules"`
+	Alternatives    []string  `json:"alternatives,omitempty"`
+	SupersededBy    string    `json:"supersededBy,omitempty"`
+	Author          string    `json:"author,omitempty"`
+	Date            time.Time `json:"date"`
+	LastReviewed    *time.Time `json:"lastReviewed,omitempty"`
+	FilePath        string    `json:"filePath"`        // relative path to .md file
+}
+
+// ADRStatus represents valid ADR statuses
+type ADRStatus string
+
+const (
+	StatusProposed   ADRStatus = "proposed"
+	StatusAccepted   ADRStatus = "accepted"
+	StatusDeprecated ADRStatus = "deprecated"
+	StatusSuperseded ADRStatus = "superseded"
+)
+
+// IsValidStatus checks if a status string is valid
+func IsValidStatus(status string) bool {
+	switch ADRStatus(status) {
+	case StatusProposed, StatusAccepted, StatusDeprecated, StatusSuperseded:
+		return true
+	default:
+		return false
+	}
+}
+
+// ADRTemplate is the template for generating new ADRs
+const ADRTemplate = `# {{.ID}}: {{.Title}}
+
+**Status:** {{.Status}}
+
+**Date:** {{.Date}}
+{{if .Author}}
+**Author:** {{.Author}}
+{{end}}
+## Context
+
+{{.Context}}
+
+## Decision
+
+{{.Decision}}
+
+## Consequences
+
+{{range .Consequences}}- {{.}}
+{{end}}
+{{if .AffectedModules}}
+## Affected Modules
+
+{{range .AffectedModules}}- {{.}}
+{{end}}{{end}}
+{{if .Alternatives}}
+## Alternatives Considered
+
+{{range .Alternatives}}- {{.}}
+{{end}}{{end}}
+`

--- a/internal/decisions/writer.go
+++ b/internal/decisions/writer.go
@@ -1,0 +1,230 @@
+package decisions
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+)
+
+// Writer generates ADR markdown files
+type Writer struct {
+	repoRoot   string
+	outputDir  string // relative to repoRoot
+}
+
+// NewWriter creates a new ADR writer
+func NewWriter(repoRoot, outputDir string) *Writer {
+	return &Writer{
+		repoRoot:  repoRoot,
+		outputDir: outputDir,
+	}
+}
+
+// CreateADR creates a new ADR file and returns the relative path
+func (w *Writer) CreateADR(adr *ArchitecturalDecision) (string, error) {
+	// Ensure output directory exists
+	fullDir := filepath.Join(w.repoRoot, w.outputDir)
+	if err := os.MkdirAll(fullDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Generate filename
+	filename := generateFilename(adr.ID, adr.Title)
+	relPath := filepath.Join(w.outputDir, filename)
+	fullPath := filepath.Join(w.repoRoot, relPath)
+
+	// Check if file already exists
+	if _, err := os.Stat(fullPath); err == nil {
+		return "", fmt.Errorf("ADR file already exists: %s", relPath)
+	}
+
+	// Generate content
+	content, err := w.generateContent(adr)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate content: %w", err)
+	}
+
+	// Write file
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		return "", fmt.Errorf("failed to write file: %w", err)
+	}
+
+	adr.FilePath = relPath
+	return relPath, nil
+}
+
+// UpdateADR updates an existing ADR file
+func (w *Writer) UpdateADR(adr *ArchitecturalDecision) error {
+	if adr.FilePath == "" {
+		return fmt.Errorf("ADR has no file path")
+	}
+
+	fullPath := filepath.Join(w.repoRoot, adr.FilePath)
+
+	// Check if file exists
+	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		return fmt.Errorf("ADR file not found: %s", adr.FilePath)
+	}
+
+	// Generate content
+	content, err := w.generateContent(adr)
+	if err != nil {
+		return fmt.Errorf("failed to generate content: %w", err)
+	}
+
+	// Write file
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}
+
+// generateContent generates the markdown content for an ADR
+func (w *Writer) generateContent(adr *ArchitecturalDecision) (string, error) {
+	tmpl, err := template.New("adr").Parse(adrTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare template data
+	data := struct {
+		ID              string
+		Title           string
+		Status          string
+		Date            string
+		Author          string
+		Context         string
+		Decision        string
+		Consequences    []string
+		AffectedModules []string
+		Alternatives    []string
+		SupersededBy    string
+	}{
+		ID:              adr.ID,
+		Title:           adr.Title,
+		Status:          adr.Status,
+		Date:            adr.Date.Format("2006-01-02"),
+		Author:          adr.Author,
+		Context:         adr.Context,
+		Decision:        adr.Decision,
+		Consequences:    adr.Consequences,
+		AffectedModules: adr.AffectedModules,
+		Alternatives:    adr.Alternatives,
+		SupersededBy:    adr.SupersededBy,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// generateFilename creates a filename for an ADR
+func generateFilename(id, title string) string {
+	// Clean title for filename
+	cleanTitle := strings.ToLower(title)
+	cleanTitle = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			return r
+		}
+		if r == ' ' || r == '-' || r == '_' {
+			return '-'
+		}
+		return -1
+	}, cleanTitle)
+
+	// Remove multiple dashes
+	for strings.Contains(cleanTitle, "--") {
+		cleanTitle = strings.ReplaceAll(cleanTitle, "--", "-")
+	}
+	cleanTitle = strings.Trim(cleanTitle, "-")
+
+	// Truncate if too long
+	if len(cleanTitle) > 50 {
+		cleanTitle = cleanTitle[:50]
+		cleanTitle = strings.TrimSuffix(cleanTitle, "-")
+	}
+
+	return fmt.Sprintf("%s-%s.md", strings.ToLower(id), cleanTitle)
+}
+
+// adrTemplate is the template for generating ADR markdown
+const adrTemplate = `# {{.ID}}: {{.Title}}
+
+**Status:** {{.Status}}
+
+**Date:** {{.Date}}
+{{if .Author}}
+**Author:** {{.Author}}
+{{end}}{{if .SupersededBy}}
+**Superseded by:** {{.SupersededBy}}
+{{end}}
+## Context
+
+{{.Context}}
+
+## Decision
+
+{{.Decision}}
+
+## Consequences
+
+{{range .Consequences}}- {{.}}
+{{end}}
+{{if .AffectedModules}}
+## Affected Modules
+
+{{range .AffectedModules}}- {{.}}
+{{end}}{{end}}{{if .Alternatives}}
+## Alternatives Considered
+
+{{range .Alternatives}}- {{.}}
+{{end}}{{end}}`
+
+// EnsureOutputDir ensures the output directory exists and returns its path
+func (w *Writer) EnsureOutputDir() (string, error) {
+	fullDir := filepath.Join(w.repoRoot, w.outputDir)
+	if err := os.MkdirAll(fullDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create directory: %w", err)
+	}
+	return w.outputDir, nil
+}
+
+// GetDefaultOutputDir returns the default ADR output directory
+func GetDefaultOutputDir(repoRoot string) string {
+	// Check for existing ADR directories
+	candidates := []string{
+		"docs/decisions",
+		"docs/adr",
+		"adr",
+		"decisions",
+	}
+
+	for _, dir := range candidates {
+		fullPath := filepath.Join(repoRoot, dir)
+		if info, err := os.Stat(fullPath); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+
+	// Default to docs/decisions
+	return "docs/decisions"
+}
+
+// NewADR creates a new ADR with default values
+func NewADR(id int, title string) *ArchitecturalDecision {
+	return &ArchitecturalDecision{
+		ID:           fmt.Sprintf("ADR-%03d", id),
+		Title:        title,
+		Status:       string(StatusProposed),
+		Date:         time.Now(),
+		Consequences: []string{},
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -489,6 +489,136 @@ func (s *MCPServer) GetToolDefinitions() []Tool {
 				},
 			},
 		},
+		{
+			Name:        "recordDecision",
+			Description: "Record an architectural decision (ADR). Creates both a markdown file and database entry. Use to document design decisions, rationale, and consequences.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"title": map[string]interface{}{
+						"type":        "string",
+						"description": "Short title for the decision (e.g., 'Use PostgreSQL for persistence')",
+					},
+					"context": map[string]interface{}{
+						"type":        "string",
+						"description": "Background and forces driving the decision",
+					},
+					"decision": map[string]interface{}{
+						"type":        "string",
+						"description": "What was decided and why",
+					},
+					"consequences": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+						"description": "List of consequences (positive and negative) of this decision",
+					},
+					"affectedModules": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+						"description": "List of module IDs affected by this decision",
+					},
+					"alternatives": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+						"description": "List of alternatives that were considered",
+					},
+					"author": map[string]interface{}{
+						"type":        "string",
+						"description": "Author of the decision",
+					},
+					"status": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"proposed", "accepted", "deprecated", "superseded"},
+						"default":     "proposed",
+						"description": "Status of the decision",
+					},
+				},
+				"required": []string{"title", "context", "decision", "consequences"},
+			},
+		},
+		{
+			Name:        "getDecisions",
+			Description: "Get architectural decisions (ADRs). Returns recorded decisions with their status, affected modules, and file paths. Use to understand past architectural choices.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"id": map[string]interface{}{
+						"type":        "string",
+						"description": "Specific decision ID (e.g., 'ADR-001'). Returns single decision with full details.",
+					},
+					"status": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"proposed", "accepted", "deprecated", "superseded"},
+						"description": "Filter by status",
+					},
+					"moduleId": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter by affected module",
+					},
+					"search": map[string]interface{}{
+						"type":        "string",
+						"description": "Search in title and ID",
+					},
+					"limit": map[string]interface{}{
+						"type":        "integer",
+						"default":     50,
+						"description": "Maximum number of decisions to return",
+					},
+				},
+			},
+		},
+		{
+			Name:        "annotateModule",
+			Description: "Add or update module metadata (responsibilities, tags, boundaries). Enhances architectural understanding without modifying code.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"moduleId": map[string]interface{}{
+						"type":        "string",
+						"description": "Module ID (typically the directory path)",
+					},
+					"responsibility": map[string]interface{}{
+						"type":        "string",
+						"description": "One-sentence description of what this module does",
+					},
+					"capabilities": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+						"description": "List of capabilities provided by this module",
+					},
+					"tags": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+						"description": "Tags for categorization (e.g., 'core', 'infrastructure', 'api')",
+					},
+					"publicPaths": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+						"description": "Paths intended as public API boundaries",
+					},
+					"internalPaths": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+						"description": "Paths intended to be internal/private",
+					},
+				},
+				"required": []string{"moduleId"},
+			},
+		},
 	}
 }
 
@@ -517,4 +647,7 @@ func (s *MCPServer) RegisterTools() {
 	s.tools["refreshArchitecture"] = s.toolRefreshArchitecture
 	s.tools["getOwnership"] = s.toolGetOwnership
 	s.tools["getModuleResponsibilities"] = s.toolGetModuleResponsibilities
+	s.tools["recordDecision"] = s.toolRecordDecision
+	s.tools["getDecisions"] = s.toolGetDecisions
+	s.tools["annotateModule"] = s.toolAnnotateModule
 }

--- a/internal/query/annotations.go
+++ b/internal/query/annotations.go
@@ -1,0 +1,114 @@
+package query
+
+import (
+	"encoding/json"
+	"time"
+
+	"ckb/internal/storage"
+)
+
+// AnnotateModuleInput represents input for annotating a module
+type AnnotateModuleInput struct {
+	ModuleId       string   `json:"moduleId"`
+	Responsibility string   `json:"responsibility,omitempty"`
+	Capabilities   []string `json:"capabilities,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	PublicPaths    []string `json:"publicPaths,omitempty"`
+	InternalPaths  []string `json:"internalPaths,omitempty"`
+}
+
+// AnnotateModuleResult represents the result of annotating a module
+type AnnotateModuleResult struct {
+	ModuleId       string       `json:"moduleId"`
+	Responsibility string       `json:"responsibility,omitempty"`
+	Capabilities   []string     `json:"capabilities,omitempty"`
+	Tags           []string     `json:"tags,omitempty"`
+	Boundaries     *Boundaries  `json:"boundaries,omitempty"`
+	Updated        bool         `json:"updated"`
+	Created        bool         `json:"created"`
+}
+
+// Boundaries represents API boundary definitions
+type Boundaries struct {
+	Public   []string `json:"public,omitempty"`
+	Internal []string `json:"internal,omitempty"`
+}
+
+// AnnotateModule adds or updates module metadata
+func (e *Engine) AnnotateModule(input *AnnotateModuleInput) (*AnnotateModuleResult, error) {
+	respRepo := storage.NewResponsibilityRepository(e.db)
+
+	// Check if module already has annotations
+	existing, err := respRepo.GetByTarget(input.ModuleId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build capabilities JSON
+	capabilitiesJSON := "[]"
+	if len(input.Capabilities) > 0 {
+		bytes, err := json.Marshal(input.Capabilities)
+		if err == nil {
+			capabilitiesJSON = string(bytes)
+		}
+	}
+
+	now := time.Now()
+	record := &storage.ResponsibilityRecord{
+		TargetID:     input.ModuleId,
+		TargetType:   "module",
+		Summary:      input.Responsibility,
+		Capabilities: capabilitiesJSON,
+		Source:       "declared",
+		Confidence:   1.0, // User-declared is high confidence
+		UpdatedAt:    now,
+	}
+
+	created := false
+	updated := false
+
+	if existing == nil {
+		// Create new record
+		if err := respRepo.Create(record); err != nil {
+			return nil, err
+		}
+		created = true
+	} else {
+		// Update existing record (merge values)
+		record.ID = existing.ID
+
+		// Merge responsibility
+		if input.Responsibility == "" && existing.Summary != "" {
+			record.Summary = existing.Summary
+		}
+
+		// Merge capabilities
+		if len(input.Capabilities) == 0 && existing.Capabilities != "" {
+			record.Capabilities = existing.Capabilities
+		}
+
+		if err := respRepo.Update(record); err != nil {
+			return nil, err
+		}
+		updated = true
+	}
+
+	// Build result
+	result := &AnnotateModuleResult{
+		ModuleId:       input.ModuleId,
+		Responsibility: input.Responsibility,
+		Capabilities:   input.Capabilities,
+		Tags:           input.Tags,
+		Updated:        updated,
+		Created:        created,
+	}
+
+	if len(input.PublicPaths) > 0 || len(input.InternalPaths) > 0 {
+		result.Boundaries = &Boundaries{
+			Public:   input.PublicPaths,
+			Internal: input.InternalPaths,
+		}
+	}
+
+	return result, nil
+}

--- a/internal/query/decisions.go
+++ b/internal/query/decisions.go
@@ -1,0 +1,372 @@
+package query
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"ckb/internal/decisions"
+	"ckb/internal/storage"
+)
+
+// DecisionResult represents the result of a decision query
+type DecisionResult struct {
+	Decision *decisions.ArchitecturalDecision `json:"decision"`
+	Source   string                           `json:"source"` // "file" | "database" | "both"
+}
+
+// DecisionsResult represents multiple decisions
+type DecisionsResult struct {
+	Decisions []*decisions.ArchitecturalDecision `json:"decisions"`
+	Total     int                                `json:"total"`
+	Query     *DecisionsQuery                    `json:"query,omitempty"`
+}
+
+// DecisionsQuery represents query parameters for decisions
+type DecisionsQuery struct {
+	Status   string `json:"status,omitempty"`
+	ModuleID string `json:"moduleId,omitempty"`
+	Search   string `json:"search,omitempty"`
+	Limit    int    `json:"limit,omitempty"`
+}
+
+// RecordDecisionInput represents input for recording a new decision
+type RecordDecisionInput struct {
+	Title           string   `json:"title"`
+	Context         string   `json:"context"`
+	Decision        string   `json:"decision"`
+	Consequences    []string `json:"consequences"`
+	AffectedModules []string `json:"affectedModules,omitempty"`
+	Alternatives    []string `json:"alternatives,omitempty"`
+	Author          string   `json:"author,omitempty"`
+	Status          string   `json:"status,omitempty"` // defaults to "proposed"
+}
+
+// RecordDecision creates a new ADR and stores it in both file system and database
+func (e *Engine) RecordDecision(input *RecordDecisionInput) (*DecisionResult, error) {
+	// Get repository for decisions
+	decisionRepo := storage.NewDecisionRepository(e.db)
+
+	// Create parser to find next ADR number
+	parser := decisions.NewParser(e.repoRoot)
+	nextNum, err := parser.GetNextADRNumber()
+	if err != nil {
+		nextNum = 1 // fallback if no existing ADRs
+	}
+
+	// Create the ADR
+	adr := decisions.NewADR(nextNum, input.Title)
+	adr.Context = input.Context
+	adr.Decision = input.Decision
+	adr.Consequences = input.Consequences
+	adr.AffectedModules = input.AffectedModules
+	adr.Alternatives = input.Alternatives
+	adr.Author = input.Author
+
+	if input.Status != "" && decisions.IsValidStatus(input.Status) {
+		adr.Status = input.Status
+	}
+
+	// Determine output directory
+	outputDir := decisions.GetDefaultOutputDir(e.repoRoot)
+
+	// Create writer and write the ADR file
+	writer := decisions.NewWriter(e.repoRoot, outputDir)
+	filePath, err := writer.CreateADR(adr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ADR file: %w", err)
+	}
+
+	// Convert affected modules to JSON for storage
+	affectedModulesJSON := "[]"
+	if len(adr.AffectedModules) > 0 {
+		bytes, err := json.Marshal(adr.AffectedModules)
+		if err == nil {
+			affectedModulesJSON = string(bytes)
+		}
+	}
+
+	// Store in database
+	record := &storage.DecisionRecord{
+		ID:              adr.ID,
+		Title:           adr.Title,
+		Status:          adr.Status,
+		AffectedModules: affectedModulesJSON,
+		FilePath:        filePath,
+		Author:          adr.Author,
+		CreatedAt:       adr.Date,
+		UpdatedAt:       adr.Date,
+	}
+
+	if err := decisionRepo.Create(record); err != nil {
+		// File was created, but DB failed - log warning but don't fail
+		e.logger.Warn("ADR file created but database storage failed", map[string]interface{}{
+			"id":    adr.ID,
+			"error": err.Error(),
+		})
+	}
+
+	return &DecisionResult{
+		Decision: adr,
+		Source:   "file",
+	}, nil
+}
+
+// GetDecision retrieves a single decision by ID
+func (e *Engine) GetDecision(id string) (*DecisionResult, error) {
+	decisionRepo := storage.NewDecisionRepository(e.db)
+
+	// Try database first
+	record, err := decisionRepo.GetByID(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query decision: %w", err)
+	}
+
+	if record != nil {
+		// Parse the file to get full content
+		parser := decisions.NewParser(e.repoRoot)
+		adr, err := parser.ParseFile(record.FilePath)
+		if err == nil {
+			return &DecisionResult{
+				Decision: adr,
+				Source:   "both",
+			}, nil
+		}
+
+		// Fall back to database-only record
+		adr = &decisions.ArchitecturalDecision{
+			ID:       record.ID,
+			Title:    record.Title,
+			Status:   record.Status,
+			FilePath: record.FilePath,
+			Author:   record.Author,
+			Date:     record.CreatedAt,
+		}
+
+		if record.AffectedModules != "" {
+			_ = json.Unmarshal([]byte(record.AffectedModules), &adr.AffectedModules)
+		}
+
+		return &DecisionResult{
+			Decision: adr,
+			Source:   "database",
+		}, nil
+	}
+
+	// Not in database - try scanning file system
+	parser := decisions.NewParser(e.repoRoot)
+	dirs := parser.FindADRDirectories()
+
+	for _, dir := range dirs {
+		adrs, err := parser.ParseDirectory(dir)
+		if err != nil {
+			continue
+		}
+		for _, adr := range adrs {
+			if adr.ID == id {
+				return &DecisionResult{
+					Decision: adr,
+					Source:   "file",
+				}, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("decision not found: %s", id)
+}
+
+// GetDecisions retrieves decisions matching the query
+func (e *Engine) GetDecisions(query *DecisionsQuery) (*DecisionsResult, error) {
+	if query == nil {
+		query = &DecisionsQuery{}
+	}
+	if query.Limit == 0 {
+		query.Limit = 50
+	}
+
+	decisionRepo := storage.NewDecisionRepository(e.db)
+	var records []*storage.DecisionRecord
+	var err error
+
+	// Query based on filters
+	switch {
+	case query.Status != "":
+		records, err = decisionRepo.GetByStatus(query.Status, query.Limit)
+	case query.ModuleID != "":
+		records, err = decisionRepo.GetByModule(query.ModuleID, query.Limit)
+	case query.Search != "":
+		records, err = decisionRepo.Search(query.Search, query.Limit)
+	default:
+		records, err = decisionRepo.ListAll(query.Limit)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to query decisions: %w", err)
+	}
+
+	// If we have database results, use them
+	if len(records) > 0 {
+		adrs := make([]*decisions.ArchitecturalDecision, 0, len(records))
+		for _, record := range records {
+			adr := &decisions.ArchitecturalDecision{
+				ID:       record.ID,
+				Title:    record.Title,
+				Status:   record.Status,
+				FilePath: record.FilePath,
+				Author:   record.Author,
+				Date:     record.CreatedAt,
+			}
+			if record.AffectedModules != "" {
+				_ = json.Unmarshal([]byte(record.AffectedModules), &adr.AffectedModules)
+			}
+			adrs = append(adrs, adr)
+		}
+
+		return &DecisionsResult{
+			Decisions: adrs,
+			Total:     len(adrs),
+			Query:     query,
+		}, nil
+	}
+
+	// Fall back to file system scan
+	parser := decisions.NewParser(e.repoRoot)
+	dirs := parser.FindADRDirectories()
+
+	var allADRs []*decisions.ArchitecturalDecision
+	for _, dir := range dirs {
+		adrs, err := parser.ParseDirectory(dir)
+		if err != nil {
+			continue
+		}
+		allADRs = append(allADRs, adrs...)
+	}
+
+	// Apply filters
+	filtered := make([]*decisions.ArchitecturalDecision, 0)
+	for _, adr := range allADRs {
+		if query.Status != "" && adr.Status != query.Status {
+			continue
+		}
+		if query.ModuleID != "" {
+			found := false
+			for _, mod := range adr.AffectedModules {
+				if mod == query.ModuleID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		filtered = append(filtered, adr)
+		if len(filtered) >= query.Limit {
+			break
+		}
+	}
+
+	return &DecisionsResult{
+		Decisions: filtered,
+		Total:     len(filtered),
+		Query:     query,
+	}, nil
+}
+
+// UpdateDecisionStatus updates the status of an existing decision
+func (e *Engine) UpdateDecisionStatus(id string, newStatus string) (*DecisionResult, error) {
+	if !decisions.IsValidStatus(newStatus) {
+		return nil, fmt.Errorf("invalid status: %s (valid: proposed, accepted, deprecated, superseded)", newStatus)
+	}
+
+	decisionRepo := storage.NewDecisionRepository(e.db)
+
+	// Get existing record
+	record, err := decisionRepo.GetByID(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get decision: %w", err)
+	}
+	if record == nil {
+		return nil, fmt.Errorf("decision not found: %s", id)
+	}
+
+	// Parse the file to get full ADR
+	parser := decisions.NewParser(e.repoRoot)
+	adr, err := parser.ParseFile(record.FilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ADR file: %w", err)
+	}
+
+	// Update status
+	adr.Status = newStatus
+
+	// Write back to file
+	outputDir := decisions.GetDefaultOutputDir(e.repoRoot)
+	writer := decisions.NewWriter(e.repoRoot, outputDir)
+	if err := writer.UpdateADR(adr); err != nil {
+		return nil, fmt.Errorf("failed to update ADR file: %w", err)
+	}
+
+	// Update database
+	record.Status = newStatus
+	record.UpdatedAt = time.Now()
+	if err := decisionRepo.Update(record); err != nil {
+		e.logger.Warn("ADR file updated but database update failed", map[string]interface{}{
+			"id":    id,
+			"error": err.Error(),
+		})
+	}
+
+	return &DecisionResult{
+		Decision: adr,
+		Source:   "both",
+	}, nil
+}
+
+// SyncDecisionsFromFiles scans the file system and syncs ADRs to the database
+func (e *Engine) SyncDecisionsFromFiles() (int, error) {
+	parser := decisions.NewParser(e.repoRoot)
+	decisionRepo := storage.NewDecisionRepository(e.db)
+
+	dirs := parser.FindADRDirectories()
+	synced := 0
+
+	for _, dir := range dirs {
+		adrs, err := parser.ParseDirectory(dir)
+		if err != nil {
+			continue
+		}
+
+		for _, adr := range adrs {
+			affectedModulesJSON := "[]"
+			if len(adr.AffectedModules) > 0 {
+				bytes, err := json.Marshal(adr.AffectedModules)
+				if err == nil {
+					affectedModulesJSON = string(bytes)
+				}
+			}
+
+			record := &storage.DecisionRecord{
+				ID:              adr.ID,
+				Title:           adr.Title,
+				Status:          adr.Status,
+				AffectedModules: affectedModulesJSON,
+				FilePath:        adr.FilePath,
+				Author:          adr.Author,
+				CreatedAt:       adr.Date,
+				UpdatedAt:       time.Now(),
+			}
+
+			if err := decisionRepo.Upsert(record); err != nil {
+				e.logger.Warn("Failed to sync ADR to database", map[string]interface{}{
+					"id":    adr.ID,
+					"error": err.Error(),
+				})
+				continue
+			}
+			synced++
+		}
+	}
+
+	return synced, nil
+}


### PR DESCRIPTION
## Summary

Implements v6.0 Phase 4 - Architectural Decision Records and module annotations:

- **ADR Parser & Writer**: Parse and generate ADR markdown files
- **Decision Storage**: Database repository for ADR metadata
- **recordDecision Tool**: Create new ADRs with file + database storage
- **getDecisions Tool**: Query ADRs by ID, status, module, or search
- **annotateModule Tool**: Add/update module responsibilities and boundaries

## New Files

- `internal/decisions/types.go` - ArchitecturalDecision struct, status constants
- `internal/decisions/parser.go` - Parse ADR markdown with metadata extraction
- `internal/decisions/writer.go` - Generate ADR markdown from template
- `internal/query/decisions.go` - Engine methods for decision management
- `internal/query/annotations.go` - AnnotateModule for module metadata

## Test plan

- [x] Build passes
- [x] All existing tests pass
- [x] ADR files can be created with `recordDecision`
- [x] ADRs can be queried with `getDecisions`
- [x] Modules can be annotated with `annotateModule`

🤖 Generated with [Claude Code](https://claude.com/claude-code)