### PR TITLE
feat: Add --repo flag and CKB_REPO env var for Claude Desktop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,18 +485,30 @@ Add to `opencode.json` in project root:
 <details>
 <summary><strong>Claude Desktop</strong></summary>
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+Claude Desktop doesn't have a project context, so you must specify the repository path.
+
+**Automatic setup** (recommended):
+```bash
+cd /path/to/your/repo
+ckb setup --tool=claude-desktop
+```
+
+**Manual configuration** — add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 ```json
 {
   "mcpServers": {
     "ckb": {
       "command": "npx",
-      "args": ["@tastehub/ckb", "mcp"],
-      "cwd": "/path/to/your/repo"
+      "args": ["-y", "@tastehub/ckb", "mcp"],
+      "env": {
+        "CKB_REPO": "/path/to/your/repo"
+      }
     }
   }
 }
 ```
+
+The `CKB_REPO` environment variable tells CKB which repository to analyze. Claude Desktop can only work with one repository at a time.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add `--repo` flag to `ckb mcp` command for specifying repository path
- Add `CKB_REPO` environment variable support (priority: `--repo` > `CKB_REPO` > cwd)
- Update `ckb setup --tool=claude-desktop` to prompt for repository path and write config with `env.CKB_REPO`
- Fix README documentation (was incorrectly using `cwd` which doesn't work)

## Context

Claude Desktop is a standalone app without a project context. Previously, the documentation incorrectly suggested using `cwd` in the config, which doesn't actually work. The MCP server would start in an undefined directory and fail to find the CKB database.

This PR adds proper support via the `CKB_REPO` environment variable, which Claude Desktop's MCP config supports via the `env` field.

## Test plan

- [x] `ckb mcp --help` shows `--repo` flag
- [x] `ckb mcp --repo /path/to/repo` changes to that directory before starting
- [x] `CKB_REPO=/path/to/repo ckb mcp` works from any directory
- [x] `ckb setup --tool=claude-desktop` prompts for repo path and writes correct config
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)