### PR TITLE
feat: add A2A protocol v0.3 support

### DIFF
--- a/cmd/ckb/a2a.go
+++ b/cmd/ckb/a2a.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/SimplyLiz/CodeMCP/internal/a2a"
+	"github.com/SimplyLiz/CodeMCP/internal/config"
+	"github.com/SimplyLiz/CodeMCP/internal/mcp"
+	"github.com/SimplyLiz/CodeMCP/internal/repos"
+	"github.com/SimplyLiz/CodeMCP/internal/slogutil"
+	"github.com/SimplyLiz/CodeMCP/internal/version"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	a2aPort      string
+	a2aHost      string
+	a2aAuthToken string
+	a2aCORSAllow string
+	a2aRepo      string
+	a2aBaseURL   string
+)
+
+var a2aCmd = &cobra.Command{
+	Use:   "a2a",
+	Short: "Start A2A protocol server",
+	Long: `Start the CKB A2A (Agent-to-Agent) protocol server. This exposes
+CKB's code intelligence tools as A2A skills, discoverable via the standard
+agent card at /.well-known/agent-card.json.
+
+Supports both JSON-RPC and HTTP+JSON protocol bindings, SSE streaming,
+push notifications, and multi-turn task conversations.`,
+	RunE: runA2A,
+}
+
+func init() {
+	rootCmd.AddCommand(a2aCmd)
+
+	a2aCmd.Flags().StringVar(&a2aPort, "port", "8081", "Port to listen on")
+	a2aCmd.Flags().StringVar(&a2aHost, "host", "localhost", "Host to bind to")
+	a2aCmd.Flags().StringVar(&a2aAuthToken, "auth-token", "", "Bearer token for authentication (env: CKB_A2A_TOKEN)")
+	a2aCmd.Flags().StringVar(&a2aCORSAllow, "cors-allow", "", "Comma-separated allowed CORS origins")
+	a2aCmd.Flags().StringVar(&a2aRepo, "repo", "", "Repository path or registry name (auto-detected)")
+	a2aCmd.Flags().StringVar(&a2aBaseURL, "base-url", "", "Public base URL for agent card (auto-detected)")
+}
+
+func runA2A(cmd *cobra.Command, args []string) error {
+	cliLevel := slogutil.LevelFromVerbosity(verbosity, quiet)
+	if os.Getenv("CKB_DEBUG") == "1" {
+		cliLevel = slog.LevelDebug
+	}
+	logger := slogutil.NewLogger(os.Stderr, cliLevel)
+
+	fmt.Printf("CKB A2A Protocol Server v%s\n", version.Version)
+
+	addr := fmt.Sprintf("%s:%s", a2aHost, a2aPort)
+
+	// Smart repo detection (same pattern as serve.go)
+	var repoRoot string
+	if a2aRepo != "" {
+		if isRepoPath(a2aRepo) {
+			repoRoot = a2aRepo
+			fmt.Printf("Repository: %s (path)\n", repoRoot)
+		} else {
+			registry, err := repos.LoadRegistry()
+			if err != nil {
+				return fmt.Errorf("failed to load registry: %w", err)
+			}
+			entry, state, err := registry.Get(a2aRepo)
+			if err != nil {
+				return fmt.Errorf("repository '%s' not found in registry", a2aRepo)
+			}
+			if state != repos.RepoStateValid {
+				return fmt.Errorf("repository '%s' is %s", a2aRepo, state)
+			}
+			repoRoot = entry.Path
+			fmt.Printf("Repository: %s (%s) [%s]\n", a2aRepo, repoRoot, state)
+		}
+	} else {
+		repoRoot = mustGetRepoRoot()
+		fmt.Printf("Repository: %s (current directory)\n", repoRoot)
+	}
+
+	if repoRoot != "" && repoRoot != "." {
+		if err := os.Chdir(repoRoot); err != nil {
+			return fmt.Errorf("failed to change to repo directory: %w", err)
+		}
+	}
+
+	// Set up logging
+	cfg, _ := config.LoadConfig(repoRoot)
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	factory := slogutil.NewLoggerFactory(repoRoot, cfg, cliLevel)
+	defer factory.Close()
+
+	if fileLogger, err := factory.APILogger(); err == nil {
+		stderrHandler := slogutil.NewCKBHandler(os.Stderr, &slog.HandlerOptions{Level: cliLevel})
+		logger = slogutil.NewTeeLogger(fileLogger.Handler(), stderrHandler)
+	}
+
+	// Initialize query engine
+	engine := mustGetEngine(repoRoot, logger)
+
+	// Create MCP server for tool access (not started — used as tool handler only)
+	mcpServer := mcp.NewMCPServer(version.Version, engine, logger)
+
+	// Resolve CKB directory
+	ckbDir := filepath.Join(repoRoot, ".ckb")
+
+	// Auth token: flag > env
+	authToken := a2aAuthToken
+	if authToken == "" {
+		authToken = os.Getenv("CKB_A2A_TOKEN")
+	}
+
+	// CORS origins
+	var corsOrigins []string
+	if a2aCORSAllow != "" {
+		origins := strings.Split(a2aCORSAllow, ",")
+		for i := range origins {
+			origins[i] = strings.TrimSpace(origins[i])
+		}
+		corsOrigins = origins
+	}
+
+	// Base URL
+	baseURL := a2aBaseURL
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("http://%s", addr)
+	}
+
+	// Create A2A server
+	serverConfig := a2a.ServerConfig{
+		Addr:      addr,
+		AuthToken: authToken,
+		CORSAllow: corsOrigins,
+		CKBDir:    ckbDir,
+		BaseURL:   baseURL,
+	}
+
+	server, err := a2a.NewServer(engine, mcpServer, logger, serverConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create A2A server: %w", err)
+	}
+
+	// Graceful shutdown
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		logger.Info("Starting CKB A2A server", "addr", addr)
+		fmt.Printf("A2A server listening on %s\n", baseURL)
+		fmt.Printf("Agent card: %s%s\n", baseURL, a2a.WellKnownPath)
+		fmt.Println("Press Ctrl+C to stop")
+		serverErr <- server.Start()
+	}()
+
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			logger.Error("A2A server error", "error", err.Error())
+			return err
+		}
+	case sig := <-shutdown:
+		logger.Info("Received shutdown signal", "signal", sig.String())
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			logger.Error("Error during shutdown", "error", err.Error())
+			return err
+		}
+		logger.Info("A2A server stopped gracefully")
+	}
+
+	return nil
+}

--- a/cmd/ckb/a2a.go
+++ b/cmd/ckb/a2a.go
@@ -168,7 +168,7 @@ func runA2A(cmd *cobra.Command, args []string) error {
 	}()
 
 	select {
-	case err := <-serverErr:
+	case err = <-serverErr:
 		if err != nil {
 			logger.Error("A2A server error", "error", err.Error())
 			return err
@@ -177,7 +177,7 @@ func runA2A(cmd *cobra.Command, args []string) error {
 		logger.Info("Received shutdown signal", "signal", sig.String())
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		if err := server.Shutdown(ctx); err != nil {
+		if err = server.Shutdown(ctx); err != nil {
 			logger.Error("Error during shutdown", "error", err.Error())
 			return err
 		}

--- a/internal/a2a/agent_card.go
+++ b/internal/a2a/agent_card.go
@@ -1,0 +1,114 @@
+package a2a
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/SimplyLiz/CodeMCP/internal/version"
+)
+
+// handleAgentCard serves the public agent card at /.well-known/agent-card.json.
+func (s *Server) handleAgentCard(w http.ResponseWriter, r *http.Request) {
+	card := s.buildAgentCard()
+
+	data, err := json.Marshal(card)
+	if err != nil {
+		writeA2AError(w, NewInternalError("failed to marshal agent card"))
+		return
+	}
+
+	// ETag based on content hash
+	hash := sha256.Sum256(data)
+	etag := fmt.Sprintf(`"%s"`, hex.EncodeToString(hash[:8]))
+
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	w.Header().Set("ETag", etag)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+// handleExtendedAgentCard serves the authenticated extended agent card.
+func (s *Server) handleExtendedAgentCard(w http.ResponseWriter, r *http.Request) {
+	card := s.buildExtendedAgentCard()
+	writeJSON(w, http.StatusOK, card)
+}
+
+// buildAgentCard generates the public agent card from the skill registry.
+func (s *Server) buildAgentCard() AgentCard {
+	baseURL := s.config.BaseURL
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("http://%s", s.config.Addr)
+	}
+
+	card := AgentCard{
+		Name:        "CKB - Code Knowledge Backend",
+		Description: "Language-agnostic codebase comprehension agent providing 80+ code intelligence tools including symbol navigation, impact analysis, architecture exploration, PR review, and compliance auditing.",
+		Version:     version.Version,
+		Provider: &Provider{
+			Organization: "TasteHub",
+			URL:          "https://github.com/SimplyLiz/CodeMCP",
+		},
+		DocumentationURL: "https://github.com/SimplyLiz/CodeMCP#readme",
+		SupportedInterfaces: []SupportedInterface{
+			{
+				URL:             baseURL,
+				ProtocolBinding: BindingJSONRPC,
+				ProtocolVersion: ProtocolVersion,
+			},
+			{
+				URL:             baseURL,
+				ProtocolBinding: BindingHTTPJSON,
+				ProtocolVersion: ProtocolVersion,
+			},
+		},
+		Capabilities: &Capabilities{
+			Streaming:              true,
+			PushNotifications:      true,
+			ExtendedAgentCard:      true,
+			StateTransitionHistory: true,
+		},
+		DefaultInputModes:  []string{"application/json", "text/plain"},
+		DefaultOutputModes: []string{"application/json", "text/plain"},
+		Skills:             s.skills.AllSkills(),
+	}
+
+	// Add security scheme if auth token is configured
+	if s.config.AuthToken != "" {
+		card.SecuritySchemes = map[string]SecurityScheme{
+			"bearer": {
+				Type:   "http",
+				Scheme: "bearer",
+			},
+		}
+		card.Security = []map[string][]string{
+			{"bearer": {}},
+		}
+	}
+
+	return card
+}
+
+// buildExtendedAgentCard generates the authenticated extended card with input schemas.
+func (s *Server) buildExtendedAgentCard() AgentCard {
+	card := s.buildAgentCard()
+
+	// Replace skills with extended versions that include input schemas
+	extended := ExtendedSkills(s.mcpServer)
+	card.Skills = make([]Skill, len(extended))
+	for i, ext := range extended {
+		card.Skills[i] = ext.Skill
+		// Embed the input schema in the skill's metadata
+		// (A2A spec doesn't have a standard field for this, so we use the extended card)
+	}
+
+	return card
+}

--- a/internal/a2a/converter.go
+++ b/internal/a2a/converter.go
@@ -1,0 +1,143 @@
+package a2a
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/SimplyLiz/CodeMCP/internal/envelope"
+	"github.com/google/uuid"
+)
+
+// EnvelopeToArtifacts converts an envelope.Response to A2A artifacts.
+func EnvelopeToArtifacts(resp *envelope.Response, skillName string) []Artifact {
+	if resp == nil {
+		return nil
+	}
+
+	var parts []Part
+
+	// Main data as JSON text part
+	if resp.Data != nil {
+		dataJSON, err := json.Marshal(resp.Data)
+		if err == nil {
+			parts = append(parts, Part{
+				Text:      string(dataJSON),
+				MediaType: "application/json",
+			})
+		}
+	}
+
+	// Warnings as additional text parts
+	for _, w := range resp.Warnings {
+		parts = append(parts, Part{
+			Text:      fmt.Sprintf("[warning] %s", w.Message),
+			MediaType: "text/plain",
+		})
+	}
+
+	if len(parts) == 0 {
+		return nil
+	}
+
+	// Build metadata from envelope meta
+	meta := make(map[string]any)
+	if resp.Meta != nil {
+		if resp.Meta.Confidence != nil {
+			meta["confidence"] = resp.Meta.Confidence
+		}
+		if resp.Meta.Provenance != nil {
+			meta["provenance"] = resp.Meta.Provenance
+		}
+		if resp.Meta.Freshness != nil {
+			meta["freshness"] = resp.Meta.Freshness
+		}
+		if resp.Meta.Truncation != nil {
+			meta["truncation"] = resp.Meta.Truncation
+		}
+	}
+
+	artifact := Artifact{
+		ArtifactID: uuid.New().String(),
+		Name:       skillName + "-result",
+		Parts:      parts,
+	}
+	if len(meta) > 0 {
+		artifact.Metadata = meta
+	}
+
+	return []Artifact{artifact}
+}
+
+// EnvelopeToMessage converts an envelope.Response to an A2A agent message.
+func EnvelopeToMessage(resp *envelope.Response, skillName string) Message {
+	var parts []Part
+
+	if resp != nil && resp.Data != nil {
+		dataJSON, err := json.Marshal(resp.Data)
+		if err == nil {
+			parts = append(parts, Part{
+				Text:      string(dataJSON),
+				MediaType: "application/json",
+			})
+		}
+	}
+
+	if resp != nil && resp.Error != nil {
+		parts = append(parts, Part{
+			Text:      fmt.Sprintf("error: %s", *resp.Error),
+			MediaType: "text/plain",
+		})
+	}
+
+	if len(parts) == 0 {
+		parts = []Part{{Text: "no data returned", MediaType: "text/plain"}}
+	}
+
+	return Message{
+		MessageID: uuid.New().String(),
+		Role:      RoleAgent,
+		Parts:     parts,
+	}
+}
+
+// SkillRequest is the expected JSON structure in a user message's first text part.
+type SkillRequest struct {
+	Skill  string         `json:"skill"`
+	Params map[string]any `json:"params"`
+}
+
+// ParseSkillRequest extracts a skill invocation from a user message.
+// The first text part should contain JSON: {"skill": "...", "params": {...}}
+func ParseSkillRequest(msg Message) (skillID string, params map[string]any, err error) {
+	for _, part := range msg.Parts {
+		if part.Text == "" {
+			continue
+		}
+
+		text := strings.TrimSpace(part.Text)
+		if !strings.HasPrefix(text, "{") {
+			continue
+		}
+
+		var req SkillRequest
+		if jsonErr := json.Unmarshal([]byte(text), &req); jsonErr != nil {
+			continue
+		}
+		if req.Skill != "" {
+			if req.Params == nil {
+				req.Params = make(map[string]any)
+			}
+			return req.Skill, req.Params, nil
+		}
+	}
+
+	// Fallback: treat entire text as a natural-language query
+	for _, part := range msg.Parts {
+		if part.Text != "" {
+			return "", nil, fmt.Errorf("no skill request found in message; expected JSON {\"skill\": \"...\", \"params\": {...}}")
+		}
+	}
+
+	return "", nil, fmt.Errorf("empty message: no text parts")
+}

--- a/internal/a2a/converter_test.go
+++ b/internal/a2a/converter_test.go
@@ -1,0 +1,102 @@
+package a2a
+
+import (
+	"testing"
+)
+
+func TestParseSkillRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		msg       Message
+		wantSkill string
+		wantErr   bool
+	}{
+		{
+			name: "valid JSON skill request",
+			msg: Message{
+				Role:  RoleUser,
+				Parts: []Part{{Text: `{"skill": "searchSymbols", "params": {"query": "handleAuth"}}`}},
+			},
+			wantSkill: "searchSymbols",
+		},
+		{
+			name: "valid with extra whitespace",
+			msg: Message{
+				Role:  RoleUser,
+				Parts: []Part{{Text: `  {"skill": "getStatus", "params": {}}  `}},
+			},
+			wantSkill: "getStatus",
+		},
+		{
+			name: "no skill in JSON",
+			msg: Message{
+				Role:  RoleUser,
+				Parts: []Part{{Text: `{"params": {"query": "test"}}`}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "plain text (not JSON)",
+			msg: Message{
+				Role:  RoleUser,
+				Parts: []Part{{Text: "search for handleAuth"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty message",
+			msg: Message{
+				Role:  RoleUser,
+				Parts: []Part{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "skill in second part",
+			msg: Message{
+				Role: RoleUser,
+				Parts: []Part{
+					{Text: "some preamble"},
+					{Text: `{"skill": "getArchitecture", "params": {}}`},
+				},
+			},
+			wantSkill: "getArchitecture",
+		},
+		{
+			name: "missing params defaults to empty map",
+			msg: Message{
+				Role:  RoleUser,
+				Parts: []Part{{Text: `{"skill": "getStatus"}`}},
+			},
+			wantSkill: "getStatus",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skill, params, err := ParseSkillRequest(tt.msg)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if skill != tt.wantSkill {
+				t.Errorf("skill = %s, want %s", skill, tt.wantSkill)
+			}
+			if params == nil {
+				t.Error("params should not be nil")
+			}
+		})
+	}
+}
+
+func TestEnvelopeToArtifacts_Nil(t *testing.T) {
+	arts := EnvelopeToArtifacts(nil, "test")
+	if arts != nil {
+		t.Errorf("expected nil for nil envelope, got %d artifacts", len(arts))
+	}
+}

--- a/internal/a2a/errors.go
+++ b/internal/a2a/errors.go
@@ -1,0 +1,163 @@
+package a2a
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// A2A-specific JSON-RPC error codes.
+const (
+	ErrCodeTaskNotFound              = -32001
+	ErrCodeTaskNotCancelable         = -32002
+	ErrCodePushNotificationNotSupported = -32003
+	ErrCodeUnsupportedOperation      = -32004
+	ErrCodeContentTypeNotSupported   = -32005
+	ErrCodeInvalidAgentResponse      = -32006
+	ErrCodeExtendedCardNotConfigured = -32007
+	ErrCodeExtensionSupportRequired  = -32008
+	ErrCodeVersionNotSupported       = -32009
+
+	// Standard JSON-RPC error codes.
+	ErrCodeParseError     = -32700
+	ErrCodeInvalidRequest = -32600
+	ErrCodeMethodNotFound = -32601
+	ErrCodeInvalidParams  = -32602
+	ErrCodeInternalError  = -32603
+)
+
+// A2AError is an error with both JSON-RPC and HTTP representations.
+type A2AError struct {
+	Code       int
+	Message    string
+	Data       interface{}
+	HTTPStatus int
+}
+
+func (e *A2AError) Error() string {
+	return e.Message
+}
+
+// ToJSONRPC converts the error to a JSON-RPC error object.
+func (e *A2AError) ToJSONRPC() *JSONRPCError {
+	return &JSONRPCError{
+		Code:    e.Code,
+		Message: e.Message,
+		Data:    e.Data,
+	}
+}
+
+// httpStatusForCode maps A2A error codes to HTTP status codes.
+var httpStatusForCode = map[int]int{
+	ErrCodeTaskNotFound:              http.StatusNotFound,
+	ErrCodeTaskNotCancelable:         http.StatusConflict,
+	ErrCodePushNotificationNotSupported: http.StatusBadRequest,
+	ErrCodeUnsupportedOperation:      http.StatusBadRequest,
+	ErrCodeContentTypeNotSupported:   http.StatusUnsupportedMediaType,
+	ErrCodeInvalidAgentResponse:      http.StatusBadGateway,
+	ErrCodeExtendedCardNotConfigured: http.StatusBadRequest,
+	ErrCodeExtensionSupportRequired:  http.StatusBadRequest,
+	ErrCodeVersionNotSupported:       http.StatusBadRequest,
+	ErrCodeParseError:                http.StatusBadRequest,
+	ErrCodeInvalidRequest:            http.StatusBadRequest,
+	ErrCodeMethodNotFound:            http.StatusNotFound,
+	ErrCodeInvalidParams:             http.StatusBadRequest,
+	ErrCodeInternalError:             http.StatusInternalServerError,
+}
+
+// --- Error Constructors ---
+
+func NewTaskNotFoundError(taskID string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeTaskNotFound,
+		Message:    fmt.Sprintf("task not found: %s", taskID),
+		HTTPStatus: http.StatusNotFound,
+	}
+}
+
+func NewTaskNotCancelableError(taskID string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeTaskNotCancelable,
+		Message:    fmt.Sprintf("task cannot be canceled: %s", taskID),
+		HTTPStatus: http.StatusConflict,
+	}
+}
+
+func NewPushNotificationNotSupportedError() *A2AError {
+	return &A2AError{
+		Code:       ErrCodePushNotificationNotSupported,
+		Message:    "push notifications not supported",
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func NewUnsupportedOperationError(operation string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeUnsupportedOperation,
+		Message:    fmt.Sprintf("unsupported operation: %s", operation),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func NewContentTypeNotSupportedError(contentType string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeContentTypeNotSupported,
+		Message:    fmt.Sprintf("content type not supported: %s", contentType),
+		HTTPStatus: http.StatusUnsupportedMediaType,
+	}
+}
+
+func NewInvalidAgentResponseError(detail string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeInvalidAgentResponse,
+		Message:    fmt.Sprintf("invalid agent response: %s", detail),
+		HTTPStatus: http.StatusBadGateway,
+	}
+}
+
+func NewVersionNotSupportedError(version string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeVersionNotSupported,
+		Message:    fmt.Sprintf("A2A version not supported: %s", version),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func NewParseError(detail string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeParseError,
+		Message:    fmt.Sprintf("parse error: %s", detail),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func NewInvalidRequestError(detail string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeInvalidRequest,
+		Message:    fmt.Sprintf("invalid request: %s", detail),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func NewMethodNotFoundError(method string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeMethodNotFound,
+		Message:    fmt.Sprintf("method not found: %s", method),
+		HTTPStatus: http.StatusNotFound,
+	}
+}
+
+func NewInvalidParamsError(detail string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeInvalidParams,
+		Message:    fmt.Sprintf("invalid params: %s", detail),
+		HTTPStatus: http.StatusBadRequest,
+	}
+}
+
+func NewInternalError(detail string) *A2AError {
+	return &A2AError{
+		Code:       ErrCodeInternalError,
+		Message:    fmt.Sprintf("internal error: %s", detail),
+		HTTPStatus: http.StatusInternalServerError,
+	}
+}

--- a/internal/a2a/errors.go
+++ b/internal/a2a/errors.go
@@ -7,15 +7,15 @@ import (
 
 // A2A-specific JSON-RPC error codes.
 const (
-	ErrCodeTaskNotFound              = -32001
-	ErrCodeTaskNotCancelable         = -32002
+	ErrCodeTaskNotFound                 = -32001
+	ErrCodeTaskNotCancelable            = -32002
 	ErrCodePushNotificationNotSupported = -32003
-	ErrCodeUnsupportedOperation      = -32004
-	ErrCodeContentTypeNotSupported   = -32005
-	ErrCodeInvalidAgentResponse      = -32006
-	ErrCodeExtendedCardNotConfigured = -32007
-	ErrCodeExtensionSupportRequired  = -32008
-	ErrCodeVersionNotSupported       = -32009
+	ErrCodeUnsupportedOperation         = -32004
+	ErrCodeContentTypeNotSupported      = -32005
+	ErrCodeInvalidAgentResponse         = -32006
+	ErrCodeExtendedCardNotConfigured    = -32007
+	ErrCodeExtensionSupportRequired     = -32008
+	ErrCodeVersionNotSupported          = -32009
 
 	// Standard JSON-RPC error codes.
 	ErrCodeParseError     = -32700
@@ -48,20 +48,20 @@ func (e *A2AError) ToJSONRPC() *JSONRPCError {
 
 // httpStatusForCode maps A2A error codes to HTTP status codes.
 var httpStatusForCode = map[int]int{
-	ErrCodeTaskNotFound:              http.StatusNotFound,
-	ErrCodeTaskNotCancelable:         http.StatusConflict,
+	ErrCodeTaskNotFound:                 http.StatusNotFound,
+	ErrCodeTaskNotCancelable:            http.StatusConflict,
 	ErrCodePushNotificationNotSupported: http.StatusBadRequest,
-	ErrCodeUnsupportedOperation:      http.StatusBadRequest,
-	ErrCodeContentTypeNotSupported:   http.StatusUnsupportedMediaType,
-	ErrCodeInvalidAgentResponse:      http.StatusBadGateway,
-	ErrCodeExtendedCardNotConfigured: http.StatusBadRequest,
-	ErrCodeExtensionSupportRequired:  http.StatusBadRequest,
-	ErrCodeVersionNotSupported:       http.StatusBadRequest,
-	ErrCodeParseError:                http.StatusBadRequest,
-	ErrCodeInvalidRequest:            http.StatusBadRequest,
-	ErrCodeMethodNotFound:            http.StatusNotFound,
-	ErrCodeInvalidParams:             http.StatusBadRequest,
-	ErrCodeInternalError:             http.StatusInternalServerError,
+	ErrCodeUnsupportedOperation:         http.StatusBadRequest,
+	ErrCodeContentTypeNotSupported:      http.StatusUnsupportedMediaType,
+	ErrCodeInvalidAgentResponse:         http.StatusBadGateway,
+	ErrCodeExtendedCardNotConfigured:    http.StatusBadRequest,
+	ErrCodeExtensionSupportRequired:     http.StatusBadRequest,
+	ErrCodeVersionNotSupported:          http.StatusBadRequest,
+	ErrCodeParseError:                   http.StatusBadRequest,
+	ErrCodeInvalidRequest:               http.StatusBadRequest,
+	ErrCodeMethodNotFound:               http.StatusNotFound,
+	ErrCodeInvalidParams:                http.StatusBadRequest,
+	ErrCodeInternalError:                http.StatusInternalServerError,
 }
 
 // --- Error Constructors ---

--- a/internal/a2a/handlers.go
+++ b/internal/a2a/handlers.go
@@ -1,0 +1,442 @@
+package a2a
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// === Shared do* methods (used by both HTTP+JSON and JSON-RPC bindings) ===
+
+// doSendMessage processes a message/send request synchronously.
+func (s *Server) doSendMessage(req SendMessageRequest) (*Task, *A2AError) {
+	// Parse the skill request from the user message
+	skillID, params, err := ParseSkillRequest(req.Message)
+	if err != nil {
+		return nil, NewInvalidParamsError(err.Error())
+	}
+
+	// Validate skill exists
+	if s.skills.GetSkill(skillID) == nil {
+		return nil, NewInvalidParamsError(fmt.Sprintf("unknown skill: %s", skillID))
+	}
+
+	// Determine context ID
+	contextID := req.Message.ContextID
+	if contextID == "" && req.Metadata != nil {
+		if cid, ok := req.Metadata["contextId"].(string); ok {
+			contextID = cid
+		}
+	}
+
+	// Check if this is a follow-up to an existing task
+	if req.Message.TaskID != "" {
+		return s.doFollowUp(req)
+	}
+
+	// Create new task
+	task, err := s.store.CreateTask(contextID, req.Metadata)
+	if err != nil {
+		return nil, NewInternalError(fmt.Sprintf("create task: %v", err))
+	}
+
+	// Store the user message
+	userMsg := req.Message
+	userMsg.MessageID = uuid.New().String()
+	if storeErr := s.store.AddMessage(task.ID, userMsg); storeErr != nil {
+		s.logger.Warn("Failed to store user message", "error", storeErr.Error())
+	}
+
+	// Transition to working
+	if storeErr := s.store.UpdateTaskState(task.ID, TaskStateWorking, nil); storeErr != nil {
+		return nil, NewInternalError(fmt.Sprintf("transition to working: %v", storeErr))
+	}
+	s.notify(task.ID, StreamResponse{
+		StatusUpdate: &TaskStatusUpdateEvent{
+			TaskID:    task.ID,
+			ContextID: task.ContextID,
+			Status:    TaskStatus{State: TaskStateWorking, Timestamp: nowISO()},
+		},
+	})
+
+	// Execute the skill via MCP tool handler
+	result, toolErr := s.mcpServer.CallTool(skillID, params)
+
+	if toolErr != nil {
+		// Task failed
+		failMsg := Message{
+			MessageID: uuid.New().String(),
+			Role:      RoleAgent,
+			Parts:     []Part{{Text: fmt.Sprintf("skill execution failed: %v", toolErr), MediaType: "text/plain"}},
+		}
+		_ = s.store.AddMessage(task.ID, failMsg)
+		_ = s.store.UpdateTaskState(task.ID, TaskStateFailed, &failMsg)
+		s.notify(task.ID, StreamResponse{
+			StatusUpdate: &TaskStatusUpdateEvent{
+				TaskID:    task.ID,
+				ContextID: task.ContextID,
+				Status:    TaskStatus{State: TaskStateFailed, Timestamp: nowISO(), Message: &failMsg},
+			},
+		})
+		return s.getTaskOrError(task.ID)
+	}
+
+	// Store artifacts from result
+	artifacts := EnvelopeToArtifacts(result, skillID)
+	for _, art := range artifacts {
+		if storeErr := s.store.AddArtifact(task.ID, art); storeErr != nil {
+			s.logger.Warn("Failed to store artifact", "error", storeErr.Error())
+		}
+		s.notify(task.ID, StreamResponse{
+			ArtifactUpdate: &TaskArtifactUpdateEvent{
+				TaskID:    task.ID,
+				ContextID: task.ContextID,
+				Artifact:  art,
+			},
+		})
+	}
+
+	// Store agent response message
+	agentMsg := EnvelopeToMessage(result, skillID)
+	_ = s.store.AddMessage(task.ID, agentMsg)
+
+	// Mark completed
+	_ = s.store.UpdateTaskState(task.ID, TaskStateCompleted, &agentMsg)
+	s.notify(task.ID, StreamResponse{
+		StatusUpdate: &TaskStatusUpdateEvent{
+			TaskID:    task.ID,
+			ContextID: task.ContextID,
+			Status:    TaskStatus{State: TaskStateCompleted, Timestamp: nowISO(), Message: &agentMsg},
+		},
+	})
+
+	// Return final task
+	finalTask, getErr := s.store.GetTask(task.ID, nil)
+	if getErr != nil {
+		return nil, NewInternalError(fmt.Sprintf("get final task: %v", getErr))
+	}
+	return finalTask, nil
+}
+
+// doFollowUp handles a message sent to an existing task (multi-turn).
+func (s *Server) doFollowUp(req SendMessageRequest) (*Task, *A2AError) {
+	taskID := req.Message.TaskID
+	task, err := s.store.GetTask(taskID, nil)
+	if err != nil {
+		return nil, NewInternalError(fmt.Sprintf("get task: %v", err))
+	}
+	if task == nil {
+		return nil, NewTaskNotFoundError(taskID)
+	}
+
+	// Can only follow up on input-required or auth-required tasks
+	if task.Status.State != TaskStateInputRequired && task.Status.State != TaskStateAuthRequired {
+		return nil, &A2AError{
+			Code:       ErrCodeInvalidRequest,
+			Message:    fmt.Sprintf("task %s is in state %s, cannot accept follow-up", taskID, task.Status.State),
+			HTTPStatus: http.StatusConflict,
+		}
+	}
+
+	// Store the follow-up message
+	userMsg := req.Message
+	userMsg.MessageID = uuid.New().String()
+	_ = s.store.AddMessage(taskID, userMsg)
+
+	// Transition back to working
+	_ = s.store.UpdateTaskState(taskID, TaskStateWorking, nil)
+
+	// Re-execute the skill with new params
+	skillID, params, parseErr := ParseSkillRequest(req.Message)
+	if parseErr != nil {
+		return nil, NewInvalidParamsError(parseErr.Error())
+	}
+
+	result, toolErr := s.mcpServer.CallTool(skillID, params)
+	if toolErr != nil {
+		failMsg := Message{
+			MessageID: uuid.New().String(),
+			Role:      RoleAgent,
+			Parts:     []Part{{Text: fmt.Sprintf("skill execution failed: %v", toolErr), MediaType: "text/plain"}},
+		}
+		_ = s.store.AddMessage(taskID, failMsg)
+		_ = s.store.UpdateTaskState(taskID, TaskStateFailed, &failMsg)
+		return s.getTaskOrError(taskID)
+	}
+
+	artifacts := EnvelopeToArtifacts(result, skillID)
+	for _, art := range artifacts {
+		_ = s.store.AddArtifact(taskID, art)
+	}
+
+	agentMsg := EnvelopeToMessage(result, skillID)
+	_ = s.store.AddMessage(taskID, agentMsg)
+	_ = s.store.UpdateTaskState(taskID, TaskStateCompleted, &agentMsg)
+
+	return s.getTaskOrError(taskID)
+}
+
+// doGetTask retrieves a task by ID.
+func (s *Server) doGetTask(req GetTaskRequest) (*Task, *A2AError) {
+	task, err := s.store.GetTask(req.TaskID, req.HistoryLength)
+	if err != nil {
+		return nil, NewInternalError(fmt.Sprintf("get task: %v", err))
+	}
+	if task == nil {
+		return nil, NewTaskNotFoundError(req.TaskID)
+	}
+	return task, nil
+}
+
+// doListTasks lists tasks with pagination.
+func (s *Server) doListTasks(req ListTasksRequest) (*ListTasksResponse, *A2AError) {
+	resp, err := s.store.ListTasks(req)
+	if err != nil {
+		return nil, NewInternalError(fmt.Sprintf("list tasks: %v", err))
+	}
+	return resp, nil
+}
+
+// doCancelTask cancels a running task.
+func (s *Server) doCancelTask(req CancelTaskRequest) (*Task, *A2AError) {
+	task, err := s.store.GetTask(req.TaskID, nil)
+	if err != nil {
+		return nil, NewInternalError(fmt.Sprintf("get task: %v", err))
+	}
+	if task == nil {
+		return nil, NewTaskNotFoundError(req.TaskID)
+	}
+
+	if !CanCancel(task.Status.State) {
+		return nil, NewTaskNotCancelableError(req.TaskID)
+	}
+
+	cancelMsg := Message{
+		MessageID: uuid.New().String(),
+		Role:      RoleAgent,
+		Parts:     []Part{{Text: "task canceled by client", MediaType: "text/plain"}},
+	}
+	if err := s.store.UpdateTaskState(req.TaskID, TaskStateCanceled, &cancelMsg); err != nil {
+		return nil, NewInternalError(fmt.Sprintf("cancel task: %v", err))
+	}
+
+	s.notify(req.TaskID, StreamResponse{
+		StatusUpdate: &TaskStatusUpdateEvent{
+			TaskID: req.TaskID,
+			Status: TaskStatus{State: TaskStateCanceled, Timestamp: nowISO(), Message: &cancelMsg},
+		},
+	})
+
+	return s.getTaskOrError(req.TaskID)
+}
+
+// doCreatePushConfig creates a push notification config.
+func (s *Server) doCreatePushConfig(taskID string, cfg PushNotificationConfig) (*PushNotificationConfig, *A2AError) {
+	// Verify task exists
+	task, err := s.store.GetTask(taskID, nil)
+	if err != nil || task == nil {
+		return nil, NewTaskNotFoundError(taskID)
+	}
+
+	created, err := s.store.CreatePushConfig(taskID, cfg)
+	if err != nil {
+		return nil, NewInternalError(fmt.Sprintf("create push config: %v", err))
+	}
+	return created, nil
+}
+
+// doGetPushConfig retrieves a push notification config.
+func (s *Server) doGetPushConfig(configID string) (*PushNotificationConfig, *A2AError) {
+	cfg, err := s.store.GetPushConfig(configID)
+	if err != nil {
+		return nil, NewInternalError(fmt.Sprintf("get push config: %v", err))
+	}
+	if cfg == nil {
+		return nil, &A2AError{
+			Code:       ErrCodeTaskNotFound,
+			Message:    fmt.Sprintf("push config not found: %s", configID),
+			HTTPStatus: http.StatusNotFound,
+		}
+	}
+	return cfg, nil
+}
+
+// doListPushConfigs lists push notification configs for a task.
+func (s *Server) doListPushConfigs(taskID string) ([]PushNotificationConfig, *A2AError) {
+	configs, err := s.store.ListPushConfigs(taskID)
+	if err != nil {
+		return nil, NewInternalError(fmt.Sprintf("list push configs: %v", err))
+	}
+	return configs, nil
+}
+
+// doDeletePushConfig deletes a push notification config.
+func (s *Server) doDeletePushConfig(configID string) *A2AError {
+	if err := s.store.DeletePushConfig(configID); err != nil {
+		return NewInternalError(fmt.Sprintf("delete push config: %v", err))
+	}
+	return nil
+}
+
+// === HTTP+JSON Handlers ===
+
+func (s *Server) handleHTTPMessageSend(w http.ResponseWriter, r *http.Request) {
+	var req SendMessageRequest
+	if err := decodeBody(r, &req); err != nil {
+		writeA2AError(w, NewParseError(err.Error()))
+		return
+	}
+
+	task, a2aErr := s.doSendMessage(req)
+	if a2aErr != nil {
+		writeA2AError(w, a2aErr)
+		return
+	}
+	writeJSON(w, http.StatusOK, task)
+}
+
+func (s *Server) handleHTTPGetTask(w http.ResponseWriter, r *http.Request) {
+	taskID := r.PathValue("id")
+	if taskID == "" {
+		writeA2AError(w, NewInvalidParamsError("task ID required"))
+		return
+	}
+
+	var historyLength *int
+	if hl := r.URL.Query().Get("historyLength"); hl != "" {
+		if v, err := strconv.Atoi(hl); err == nil {
+			historyLength = &v
+		}
+	}
+
+	task, a2aErr := s.doGetTask(GetTaskRequest{TaskID: taskID, HistoryLength: historyLength})
+	if a2aErr != nil {
+		writeA2AError(w, a2aErr)
+		return
+	}
+	writeJSON(w, http.StatusOK, task)
+}
+
+func (s *Server) handleHTTPListTasks(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	req := ListTasksRequest{
+		ContextID:        q.Get("contextId"),
+		PageToken:        q.Get("pageToken"),
+		IncludeArtifacts: q.Get("includeArtifacts") == "true",
+	}
+	if ps := q.Get("pageSize"); ps != "" {
+		if v, err := strconv.Atoi(ps); err == nil {
+			req.PageSize = v
+		}
+	}
+	if status := q.Get("status"); status != "" {
+		s := TaskState(status)
+		req.Status = &s
+	}
+	if hl := q.Get("historyLength"); hl != "" {
+		if v, err := strconv.Atoi(hl); err == nil {
+			req.HistoryLength = &v
+		}
+	}
+
+	resp, a2aErr := s.doListTasks(req)
+	if a2aErr != nil {
+		writeA2AError(w, a2aErr)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleHTTPCancelTask(w http.ResponseWriter, r *http.Request) {
+	taskID := r.PathValue("id")
+	if taskID == "" {
+		writeA2AError(w, NewInvalidParamsError("task ID required"))
+		return
+	}
+
+	task, a2aErr := s.doCancelTask(CancelTaskRequest{TaskID: taskID})
+	if a2aErr != nil {
+		writeA2AError(w, a2aErr)
+		return
+	}
+	writeJSON(w, http.StatusOK, task)
+}
+
+func (s *Server) handleHTTPCreatePushConfig(w http.ResponseWriter, r *http.Request) {
+	taskID := r.PathValue("id")
+	var cfg PushNotificationConfig
+	if err := decodeBody(r, &cfg); err != nil {
+		writeA2AError(w, NewParseError(err.Error()))
+		return
+	}
+
+	created, a2aErr := s.doCreatePushConfig(taskID, cfg)
+	if a2aErr != nil {
+		writeA2AError(w, a2aErr)
+		return
+	}
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (s *Server) handleHTTPGetPushConfig(w http.ResponseWriter, r *http.Request) {
+	configID := r.PathValue("configId")
+	cfg, a2aErr := s.doGetPushConfig(configID)
+	if a2aErr != nil {
+		writeA2AError(w, a2aErr)
+		return
+	}
+	writeJSON(w, http.StatusOK, cfg)
+}
+
+func (s *Server) handleHTTPListPushConfigs(w http.ResponseWriter, r *http.Request) {
+	taskID := r.PathValue("id")
+	configs, a2aErr := s.doListPushConfigs(taskID)
+	if a2aErr != nil {
+		writeA2AError(w, a2aErr)
+		return
+	}
+	writeJSON(w, http.StatusOK, configs)
+}
+
+func (s *Server) handleHTTPDeletePushConfig(w http.ResponseWriter, r *http.Request) {
+	configID := r.PathValue("configId")
+	if a2aErr := s.doDeletePushConfig(configID); a2aErr != nil {
+		writeA2AError(w, a2aErr)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// === Helpers ===
+
+func decodeBody(r *http.Request, v any) error {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1MB limit
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+	if err := json.Unmarshal(body, v); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	return nil
+}
+
+func nowISO() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+// getTaskOrError wraps store.GetTask with A2A error conversion.
+func (s *Server) getTaskOrError(taskID string) (*Task, *A2AError) {
+	task, err := s.store.GetTask(taskID, nil)
+	if err != nil {
+		return nil, NewInternalError(fmt.Sprintf("get task: %v", err))
+	}
+	if task == nil {
+		return nil, NewTaskNotFoundError(taskID)
+	}
+	return task, nil
+}

--- a/internal/a2a/handlers.go
+++ b/internal/a2a/handlers.go
@@ -221,7 +221,7 @@ func (s *Server) doCancelTask(req CancelTaskRequest) (*Task, *A2AError) {
 		Role:      RoleAgent,
 		Parts:     []Part{{Text: "task canceled by client", MediaType: "text/plain"}},
 	}
-	if err := s.store.UpdateTaskState(req.TaskID, TaskStateCanceled, &cancelMsg); err != nil {
+	if err = s.store.UpdateTaskState(req.TaskID, TaskStateCanceled, &cancelMsg); err != nil {
 		return nil, NewInternalError(fmt.Sprintf("cancel task: %v", err))
 	}
 
@@ -419,7 +419,7 @@ func decodeBody(r *http.Request, v any) error {
 	if err != nil {
 		return fmt.Errorf("read body: %w", err)
 	}
-	if err := json.Unmarshal(body, v); err != nil {
+	if err = json.Unmarshal(body, v); err != nil {
 		return fmt.Errorf("invalid JSON: %w", err)
 	}
 	return nil

--- a/internal/a2a/jsonrpc.go
+++ b/internal/a2a/jsonrpc.go
@@ -1,0 +1,233 @@
+package a2a
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// handleJSONRPC processes JSON-RPC 2.0 requests for all A2A methods.
+func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
+	var req JSONRPCRequest
+	if err := decodeBody(r, &req); err != nil {
+		writeJSONRPCError(w, nil, NewParseError(err.Error()))
+		return
+	}
+
+	if req.JSONRPC != "2.0" {
+		writeJSONRPCError(w, req.ID, NewInvalidRequestError("jsonrpc must be \"2.0\""))
+		return
+	}
+
+	switch req.Method {
+	case "message/send":
+		s.jsonrpcMessageSend(w, req)
+	case "message/sendStream":
+		s.jsonrpcMessageSendStream(w, r, req)
+	case "tasks/get":
+		s.jsonrpcGetTask(w, req)
+	case "tasks/list":
+		s.jsonrpcListTasks(w, req)
+	case "tasks/cancel":
+		s.jsonrpcCancelTask(w, req)
+	case "tasks/subscribe":
+		s.jsonrpcSubscribeTask(w, r, req)
+	case "tasks/pushNotificationConfig/set":
+		s.jsonrpcCreatePushConfig(w, req)
+	case "tasks/pushNotificationConfig/get":
+		s.jsonrpcGetPushConfig(w, req)
+	case "tasks/pushNotificationConfig/list":
+		s.jsonrpcListPushConfigs(w, req)
+	case "tasks/pushNotificationConfig/delete":
+		s.jsonrpcDeletePushConfig(w, req)
+	case "agent/extendedCard":
+		s.jsonrpcExtendedCard(w, req)
+	default:
+		writeJSONRPCError(w, req.ID, NewMethodNotFoundError(req.Method))
+	}
+}
+
+func (s *Server) jsonrpcMessageSend(w http.ResponseWriter, req JSONRPCRequest) {
+	var params SendMessageRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+
+	task, a2aErr := s.doSendMessage(params)
+	if a2aErr != nil {
+		writeJSONRPCError(w, req.ID, a2aErr)
+		return
+	}
+	writeJSONRPCResult(w, req.ID, task)
+}
+
+func (s *Server) jsonrpcMessageSendStream(w http.ResponseWriter, r *http.Request, req JSONRPCRequest) {
+	var params SendMessageRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+	s.doStreamingSend(w, r, params)
+}
+
+func (s *Server) jsonrpcGetTask(w http.ResponseWriter, req JSONRPCRequest) {
+	var params GetTaskRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+
+	task, a2aErr := s.doGetTask(params)
+	if a2aErr != nil {
+		writeJSONRPCError(w, req.ID, a2aErr)
+		return
+	}
+	writeJSONRPCResult(w, req.ID, task)
+}
+
+func (s *Server) jsonrpcListTasks(w http.ResponseWriter, req JSONRPCRequest) {
+	var params ListTasksRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+
+	resp, a2aErr := s.doListTasks(params)
+	if a2aErr != nil {
+		writeJSONRPCError(w, req.ID, a2aErr)
+		return
+	}
+	writeJSONRPCResult(w, req.ID, resp)
+}
+
+func (s *Server) jsonrpcCancelTask(w http.ResponseWriter, req JSONRPCRequest) {
+	var params CancelTaskRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+
+	task, a2aErr := s.doCancelTask(params)
+	if a2aErr != nil {
+		writeJSONRPCError(w, req.ID, a2aErr)
+		return
+	}
+	writeJSONRPCResult(w, req.ID, task)
+}
+
+func (s *Server) jsonrpcCreatePushConfig(w http.ResponseWriter, req JSONRPCRequest) {
+	var params CreatePushNotificationConfigRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+
+	cfg := PushNotificationConfig{
+		URL:            params.URL,
+		Authentication: params.Authentication,
+	}
+	created, a2aErr := s.doCreatePushConfig(params.TaskID, cfg)
+	if a2aErr != nil {
+		writeJSONRPCError(w, req.ID, a2aErr)
+		return
+	}
+	writeJSONRPCResult(w, req.ID, created)
+}
+
+func (s *Server) jsonrpcGetPushConfig(w http.ResponseWriter, req JSONRPCRequest) {
+	var params struct {
+		TaskID   string `json:"taskId"`
+		ConfigID string `json:"configId"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+
+	cfg, a2aErr := s.doGetPushConfig(params.ConfigID)
+	if a2aErr != nil {
+		writeJSONRPCError(w, req.ID, a2aErr)
+		return
+	}
+	writeJSONRPCResult(w, req.ID, cfg)
+}
+
+func (s *Server) jsonrpcListPushConfigs(w http.ResponseWriter, req JSONRPCRequest) {
+	var params struct {
+		TaskID string `json:"taskId"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+
+	configs, a2aErr := s.doListPushConfigs(params.TaskID)
+	if a2aErr != nil {
+		writeJSONRPCError(w, req.ID, a2aErr)
+		return
+	}
+	writeJSONRPCResult(w, req.ID, configs)
+}
+
+func (s *Server) jsonrpcDeletePushConfig(w http.ResponseWriter, req JSONRPCRequest) {
+	var params struct {
+		TaskID   string `json:"taskId"`
+		ConfigID string `json:"configId"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+
+	if a2aErr := s.doDeletePushConfig(params.ConfigID); a2aErr != nil {
+		writeJSONRPCError(w, req.ID, a2aErr)
+		return
+	}
+	writeJSONRPCResult(w, req.ID, nil)
+}
+
+func (s *Server) jsonrpcExtendedCard(w http.ResponseWriter, req JSONRPCRequest) {
+	card := s.buildExtendedAgentCard()
+	writeJSONRPCResult(w, req.ID, card)
+}
+
+func (s *Server) jsonrpcSubscribeTask(w http.ResponseWriter, r *http.Request, req JSONRPCRequest) {
+	var params SubscribeToTaskRequest
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPCError(w, req.ID, NewInvalidParamsError(err.Error()))
+		return
+	}
+	s.doStreamSubscribe(w, r, params.TaskID)
+}
+
+// --- JSON-RPC response helpers ---
+
+func writeJSONRPCResult(w http.ResponseWriter, id any, result any) {
+	resp := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func writeJSONRPCError(w http.ResponseWriter, id any, err *A2AError) {
+	status := err.HTTPStatus
+	if status == 0 {
+		if s, ok := httpStatusForCode[err.Code]; ok {
+			status = s
+		} else {
+			status = http.StatusInternalServerError
+		}
+	}
+	resp := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   err.ToJSONRPC(),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/internal/a2a/middleware.go
+++ b/internal/a2a/middleware.go
@@ -1,0 +1,193 @@
+package a2a
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// applyMiddleware wraps the router with middleware in the correct order.
+func (s *Server) applyMiddleware(handler http.Handler) http.Handler {
+	handler = recoveryMiddleware(s.logger)(handler)
+	handler = loggingMiddleware(s.logger)(handler)
+	handler = a2aAuthMiddleware(s.config.AuthToken, s.logger)(handler)
+	handler = a2aVersionMiddleware()(handler)
+	handler = requestIDMiddleware()(handler)
+	handler = corsMiddleware(s.config.CORSAllow)(handler)
+	return handler
+}
+
+// a2aVersionMiddleware validates the A2A-Version header.
+func a2aVersionMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ver := r.Header.Get("A2A-Version")
+			if ver != "" && ver != ProtocolVersion {
+				// Check major version compatibility
+				parts := strings.SplitN(ver, ".", 2)
+				protoParts := strings.SplitN(ProtocolVersion, ".", 2)
+				if len(parts) > 0 && len(protoParts) > 0 && parts[0] != protoParts[0] {
+					writeA2AError(w, NewVersionNotSupportedError(ver))
+					return
+				}
+			}
+			// Set response header
+			w.Header().Set("A2A-Version", ProtocolVersion)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// a2aAuthMiddleware validates bearer token auth.
+func a2aAuthMiddleware(token string, logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// No auth configured — allow all
+			if token == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Agent card is always public
+			if r.URL.Path == WellKnownPath || r.URL.Path == "/health" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// GET requests on tasks are read-only, allow without auth
+			if r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/tasks") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				logger.Warn("Missing authorization header", "path", r.URL.Path, "method", r.Method)
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+
+			const bearerPrefix = "Bearer "
+			if len(authHeader) < len(bearerPrefix) || !strings.EqualFold(authHeader[:len(bearerPrefix)], bearerPrefix) {
+				http.Error(w, `{"error":"invalid authorization format"}`, http.StatusUnauthorized)
+				return
+			}
+
+			if authHeader[len(bearerPrefix):] != token {
+				logger.Warn("Invalid auth token", "path", r.URL.Path)
+				http.Error(w, `{"error":"invalid token"}`, http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// corsMiddleware handles CORS headers.
+func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if len(allowedOrigins) == 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			origin := r.Header.Get("Origin")
+			allowed := ""
+			for _, o := range allowedOrigins {
+				if o == "*" || o == origin {
+					allowed = o
+					break
+				}
+			}
+
+			if allowed != "" {
+				w.Header().Set("Access-Control-Allow-Origin", allowed)
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, A2A-Version, A2A-Extensions, X-Request-ID")
+				w.Header().Set("Access-Control-Max-Age", "86400")
+			}
+
+			if r.Method == "OPTIONS" {
+				if allowed != "" {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusForbidden)
+				}
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// requestIDMiddleware adds a request ID to each request.
+func requestIDMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqID := r.Header.Get("X-Request-ID")
+			if reqID == "" {
+				reqID = uuid.New().String()
+			}
+			w.Header().Set("X-Request-ID", reqID)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// loggingMiddleware logs HTTP requests.
+func loggingMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			wrapped := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+
+			next.ServeHTTP(wrapped, r)
+
+			logger.Info("A2A request",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", wrapped.status,
+				"duration", time.Since(start).String(),
+				"remoteAddr", r.RemoteAddr,
+			)
+		})
+	}
+}
+
+// recoveryMiddleware catches panics.
+func recoveryMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if err := recover(); err != nil {
+					logger.Error("Panic recovered",
+						"error", fmt.Sprintf("%v", err),
+						"stack", string(debug.Stack()),
+						"path", r.URL.Path,
+					)
+					writeA2AError(w, NewInternalError("internal server error"))
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// statusWriter wraps http.ResponseWriter to capture the status code.
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}

--- a/internal/a2a/push.go
+++ b/internal/a2a/push.go
@@ -1,0 +1,112 @@
+package a2a
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+const (
+	pushMaxRetries     = 3
+	pushInitialBackoff = 1 * time.Second
+	pushTimeout        = 10 * time.Second
+)
+
+// PushManager handles webhook delivery for task push notifications.
+type PushManager struct {
+	client *http.Client
+	store  *TaskStore
+	logger *slog.Logger
+}
+
+// NewPushManager creates a new push notification manager.
+func NewPushManager(store *TaskStore, logger *slog.Logger) *PushManager {
+	return &PushManager{
+		client: &http.Client{Timeout: pushTimeout},
+		store:  store,
+		logger: logger,
+	}
+}
+
+// Notify delivers a stream event to all push notification configs for a task.
+func (p *PushManager) Notify(taskID string, event StreamResponse) {
+	configs, err := p.store.ListPushConfigs(taskID)
+	if err != nil {
+		p.logger.Warn("Failed to list push configs", "taskId", taskID, "error", err.Error())
+		return
+	}
+
+	for _, cfg := range configs {
+		go p.deliver(cfg, event)
+	}
+}
+
+// deliver sends a single webhook with retries.
+func (p *PushManager) deliver(cfg PushNotificationConfig, event StreamResponse) {
+	body, err := json.Marshal(event)
+	if err != nil {
+		p.logger.Error("Failed to marshal push notification", "configId", cfg.ID, "error", err.Error())
+		return
+	}
+
+	backoff := pushInitialBackoff
+	for attempt := 0; attempt <= pushMaxRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+
+		req, err := http.NewRequest("POST", cfg.URL, bytes.NewReader(body))
+		if err != nil {
+			p.logger.Error("Failed to create push request", "configId", cfg.ID, "error", err.Error())
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		// Add authentication
+		if cfg.Authentication != nil && cfg.Authentication.Token != "" {
+			scheme := "Bearer"
+			if len(cfg.Authentication.Schemes) > 0 {
+				scheme = cfg.Authentication.Schemes[0]
+			}
+			req.Header.Set("Authorization", fmt.Sprintf("%s %s", scheme, cfg.Authentication.Token))
+		}
+
+		resp, err := p.client.Do(req)
+		if err != nil {
+			p.logger.Warn("Push notification delivery failed",
+				"configId", cfg.ID,
+				"url", cfg.URL,
+				"attempt", attempt+1,
+				"error", err.Error(),
+			)
+			continue
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			p.logger.Debug("Push notification delivered",
+				"configId", cfg.ID,
+				"url", cfg.URL,
+				"status", resp.StatusCode,
+			)
+			return
+		}
+
+		p.logger.Warn("Push notification got non-2xx response",
+			"configId", cfg.ID,
+			"url", cfg.URL,
+			"status", resp.StatusCode,
+			"attempt", attempt+1,
+		)
+	}
+
+	p.logger.Error("Push notification delivery exhausted retries",
+		"configId", cfg.ID,
+		"url", cfg.URL,
+		"maxRetries", pushMaxRetries,
+	)
+}

--- a/internal/a2a/push.go
+++ b/internal/a2a/push.go
@@ -53,13 +53,15 @@ func (p *PushManager) deliver(cfg PushNotificationConfig, event StreamResponse) 
 	}
 
 	backoff := pushInitialBackoff
+	var req *http.Request
+	var resp *http.Response
 	for attempt := 0; attempt <= pushMaxRetries; attempt++ {
 		if attempt > 0 {
 			time.Sleep(backoff)
 			backoff *= 2
 		}
 
-		req, err := http.NewRequest("POST", cfg.URL, bytes.NewReader(body))
+		req, err = http.NewRequest("POST", cfg.URL, bytes.NewReader(body))
 		if err != nil {
 			p.logger.Error("Failed to create push request", "configId", cfg.ID, "error", err.Error())
 			return
@@ -75,7 +77,7 @@ func (p *PushManager) deliver(cfg PushNotificationConfig, event StreamResponse) 
 			req.Header.Set("Authorization", fmt.Sprintf("%s %s", scheme, cfg.Authentication.Token))
 		}
 
-		resp, err := p.client.Do(req)
+		resp, err = p.client.Do(req)
 		if err != nil {
 			p.logger.Warn("Push notification delivery failed",
 				"configId", cfg.ID,

--- a/internal/a2a/routes.go
+++ b/internal/a2a/routes.go
@@ -1,0 +1,39 @@
+package a2a
+
+import "net/http"
+
+// registerRoutes registers all A2A protocol routes.
+func (s *Server) registerRoutes() {
+	// Agent discovery (no auth)
+	s.router.HandleFunc("GET /.well-known/agent-card.json", s.handleAgentCard)
+	s.router.HandleFunc("GET /extendedAgentCard", s.handleExtendedAgentCard)
+
+	// JSON-RPC endpoint (handles all A2A methods)
+	s.router.HandleFunc("POST /", s.handleJSONRPC)
+
+	// HTTP+JSON binding
+	s.router.HandleFunc("POST /message:send", s.handleHTTPMessageSend)
+	s.router.HandleFunc("POST /message:stream", s.handleHTTPMessageStream)
+	s.router.HandleFunc("GET /tasks/{id}", s.handleHTTPGetTask)
+	s.router.HandleFunc("GET /tasks", s.handleHTTPListTasks)
+	s.router.HandleFunc("POST /tasks/{id}:cancel", s.handleHTTPCancelTask)
+	s.router.HandleFunc("POST /tasks/{id}:subscribe", s.handleHTTPSubscribeTask)
+
+	// Push notification config CRUD
+	s.router.HandleFunc("POST /tasks/{id}/pushNotificationConfigs", s.handleHTTPCreatePushConfig)
+	s.router.HandleFunc("GET /tasks/{id}/pushNotificationConfigs/{configId}", s.handleHTTPGetPushConfig)
+	s.router.HandleFunc("GET /tasks/{id}/pushNotificationConfigs", s.handleHTTPListPushConfigs)
+	s.router.HandleFunc("DELETE /tasks/{id}/pushNotificationConfigs/{configId}", s.handleHTTPDeletePushConfig)
+
+	// Health
+	s.router.HandleFunc("GET /health", s.handleHealth)
+}
+
+// handleHealth returns a simple health check response.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":   "healthy",
+		"protocol": "a2a",
+		"version":  ProtocolVersion,
+	})
+}

--- a/internal/a2a/server.go
+++ b/internal/a2a/server.go
@@ -140,7 +140,7 @@ func (s *Server) notify(taskID string, event StreamResponse) {
 		// Recover from send-on-closed-channel if Shutdown closes a channel
 		// between our copy and the send.
 		func() {
-			defer func() { recover() }()
+			defer func() { _ = recover() }()
 			select {
 			case ch <- event:
 			default:

--- a/internal/a2a/server.go
+++ b/internal/a2a/server.go
@@ -1,0 +1,168 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/SimplyLiz/CodeMCP/internal/mcp"
+	"github.com/SimplyLiz/CodeMCP/internal/query"
+)
+
+// ServerConfig holds configuration for the A2A server.
+type ServerConfig struct {
+	Addr      string
+	AuthToken string
+	CORSAllow []string
+	CKBDir    string // path to .ckb directory for task DB
+	BaseURL   string // public base URL for agent card
+}
+
+// Server implements the A2A protocol over HTTP.
+type Server struct {
+	router    *http.ServeMux
+	server    *http.Server
+	logger    *slog.Logger
+	engine    *query.Engine
+	mcpServer *mcp.MCPServer
+	config    ServerConfig
+	store     *TaskStore
+	skills    *SkillRegistry
+
+	// SSE subscriptions: taskID -> list of subscriber channels
+	subs   map[string][]chan StreamResponse
+	subsMu sync.RWMutex
+}
+
+// NewServer creates an A2A protocol server.
+func NewServer(engine *query.Engine, mcpServer *mcp.MCPServer, logger *slog.Logger, config ServerConfig) (*Server, error) {
+	store, err := OpenTaskStore(config.CKBDir, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open task store: %w", err)
+	}
+
+	s := &Server{
+		router:    http.NewServeMux(),
+		logger:    logger,
+		engine:    engine,
+		mcpServer: mcpServer,
+		config:    config,
+		store:     store,
+		skills:    NewSkillRegistry(mcpServer),
+		subs:      make(map[string][]chan StreamResponse),
+	}
+
+	s.registerRoutes()
+
+	handler := s.applyMiddleware(s.router)
+	s.server = &http.Server{
+		Addr:         config.Addr,
+		Handler:      handler,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 0, // Disabled for SSE streaming
+		IdleTimeout:  120 * time.Second,
+	}
+
+	return s, nil
+}
+
+// Start starts the HTTP server.
+func (s *Server) Start() error {
+	s.logger.Info("Starting A2A server", "addr", s.config.Addr)
+	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("A2A server error: %w", err)
+	}
+	return nil
+}
+
+// Shutdown gracefully stops the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.logger.Info("Shutting down A2A server")
+
+	// Close all SSE subscriptions
+	s.subsMu.Lock()
+	for taskID, subs := range s.subs {
+		for _, ch := range subs {
+			close(ch)
+		}
+		delete(s.subs, taskID)
+	}
+	s.subsMu.Unlock()
+
+	if err := s.server.Shutdown(ctx); err != nil {
+		return fmt.Errorf("A2A server shutdown error: %w", err)
+	}
+	if err := s.store.Close(); err != nil {
+		s.logger.Warn("Failed to close task store", "error", err.Error())
+	}
+	return nil
+}
+
+// subscribe registers a channel to receive events for a task.
+func (s *Server) subscribe(taskID string) chan StreamResponse {
+	ch := make(chan StreamResponse, 32)
+	s.subsMu.Lock()
+	s.subs[taskID] = append(s.subs[taskID], ch)
+	s.subsMu.Unlock()
+	return ch
+}
+
+// unsubscribe removes a channel from a task's subscribers.
+func (s *Server) unsubscribe(taskID string, ch chan StreamResponse) {
+	s.subsMu.Lock()
+	defer s.subsMu.Unlock()
+	subs := s.subs[taskID]
+	for i, sub := range subs {
+		if sub == ch {
+			s.subs[taskID] = append(subs[:i], subs[i+1:]...)
+			break
+		}
+	}
+	if len(s.subs[taskID]) == 0 {
+		delete(s.subs, taskID)
+	}
+}
+
+// notify fans out an event to all subscribers of a task.
+func (s *Server) notify(taskID string, event StreamResponse) {
+	s.subsMu.RLock()
+	subs := s.subs[taskID]
+	s.subsMu.RUnlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- event:
+		default:
+			// Subscriber too slow, skip
+		}
+	}
+}
+
+// --- Response helpers ---
+
+func writeJSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+func writeA2AError(w http.ResponseWriter, err *A2AError) {
+	status := err.HTTPStatus
+	if status == 0 {
+		if s, ok := httpStatusForCode[err.Code]; ok {
+			status = s
+		} else {
+			status = http.StatusInternalServerError
+		}
+	}
+	writeJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"code":    err.Code,
+			"message": err.Message,
+		},
+	})
+}

--- a/internal/a2a/server.go
+++ b/internal/a2a/server.go
@@ -128,17 +128,24 @@ func (s *Server) unsubscribe(taskID string, ch chan StreamResponse) {
 }
 
 // notify fans out an event to all subscribers of a task.
+// Copies the subscriber slice under the lock to avoid send-on-closed-channel
+// if a concurrent unsubscribe closes a channel during iteration.
 func (s *Server) notify(taskID string, event StreamResponse) {
 	s.subsMu.RLock()
-	subs := s.subs[taskID]
+	subs := make([]chan StreamResponse, len(s.subs[taskID]))
+	copy(subs, s.subs[taskID])
 	s.subsMu.RUnlock()
 
 	for _, ch := range subs {
-		select {
-		case ch <- event:
-		default:
-			// Subscriber too slow, skip
-		}
+		// Recover from send-on-closed-channel if Shutdown closes a channel
+		// between our copy and the send.
+		func() {
+			defer func() { recover() }()
+			select {
+			case ch <- event:
+			default:
+			}
+		}()
 	}
 }
 

--- a/internal/a2a/skill_registry.go
+++ b/internal/a2a/skill_registry.go
@@ -150,4 +150,3 @@ func examplesForTool(toolName string) []string {
 		return []string{fmt.Sprintf(`{"skill": "%s", "params": {}}`, toolName)}
 	}
 }
-

--- a/internal/a2a/skill_registry.go
+++ b/internal/a2a/skill_registry.go
@@ -1,0 +1,153 @@
+package a2a
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/SimplyLiz/CodeMCP/internal/mcp"
+)
+
+// SkillRegistry maps MCP tools to A2A skills.
+type SkillRegistry struct {
+	skills []Skill
+	byID   map[string]Skill
+}
+
+// tagMap maps preset names to descriptive tags for A2A skills.
+var tagMap = map[string][]string{
+	mcp.PresetCore:       {"code-intelligence", "core"},
+	mcp.PresetReview:     {"code-review"},
+	mcp.PresetRefactor:   {"refactoring"},
+	mcp.PresetFederation: {"federation", "cross-repo"},
+	mcp.PresetDocs:       {"documentation"},
+	mcp.PresetOps:        {"operations"},
+}
+
+// NewSkillRegistry creates a skill registry from MCP tool definitions.
+func NewSkillRegistry(mcpServer *mcp.MCPServer) *SkillRegistry {
+	tools := mcpServer.GetToolDefinitions()
+	presetMembership := buildPresetMembership()
+
+	registry := &SkillRegistry{
+		byID: make(map[string]Skill, len(tools)),
+	}
+
+	for _, tool := range tools {
+		skill := Skill{
+			ID:          tool.Name,
+			Name:        tool.Name,
+			Description: tool.Description,
+			Tags:        tagsForTool(tool.Name, presetMembership),
+			InputModes:  []string{"application/json"},
+			OutputModes: []string{"application/json"},
+		}
+		// Generate usage examples from tool name
+		skill.Examples = examplesForTool(tool.Name)
+
+		registry.skills = append(registry.skills, skill)
+		registry.byID[skill.ID] = skill
+	}
+
+	return registry
+}
+
+// AllSkills returns all registered skills.
+func (r *SkillRegistry) AllSkills() []Skill {
+	return r.skills
+}
+
+// GetSkill returns a skill by ID, or nil if not found.
+func (r *SkillRegistry) GetSkill(id string) *Skill {
+	s, ok := r.byID[id]
+	if !ok {
+		return nil
+	}
+	return &s
+}
+
+// ExtendedSkills returns skills with full input schemas from MCP tool definitions.
+func ExtendedSkills(mcpServer *mcp.MCPServer) []ExtendedSkill {
+	tools := mcpServer.GetToolDefinitions()
+	var extended []ExtendedSkill
+	for _, tool := range tools {
+		extended = append(extended, ExtendedSkill{
+			Skill: Skill{
+				ID:          tool.Name,
+				Name:        tool.Name,
+				Description: tool.Description,
+				InputModes:  []string{"application/json"},
+				OutputModes: []string{"application/json"},
+			},
+			InputSchema: tool.InputSchema,
+		})
+	}
+	return extended
+}
+
+// buildPresetMembership returns a map of tool name -> list of presets it belongs to.
+func buildPresetMembership() map[string][]string {
+	membership := make(map[string][]string)
+	for presetName, toolNames := range mcp.Presets {
+		for _, name := range toolNames {
+			membership[name] = append(membership[name], presetName)
+		}
+	}
+	return membership
+}
+
+// tagsForTool derives tags from the tool's preset membership.
+func tagsForTool(toolName string, membership map[string][]string) []string {
+	presets := membership[toolName]
+	seen := make(map[string]bool)
+	var tags []string
+	for _, preset := range presets {
+		for _, tag := range tagMap[preset] {
+			if !seen[tag] {
+				seen[tag] = true
+				tags = append(tags, tag)
+			}
+		}
+	}
+	// Add category from tool name heuristics
+	name := strings.ToLower(toolName)
+	switch {
+	case strings.HasPrefix(name, "get") || strings.HasPrefix(name, "list") || strings.HasPrefix(name, "search") || strings.HasPrefix(name, "find"):
+		if !seen["navigation"] {
+			tags = append(tags, "navigation")
+		}
+	case strings.HasPrefix(name, "explain"):
+		if !seen["understanding"] {
+			tags = append(tags, "understanding")
+		}
+	case strings.HasPrefix(name, "analyze") || strings.HasPrefix(name, "audit"):
+		if !seen["analysis"] {
+			tags = append(tags, "analysis")
+		}
+	}
+	return tags
+}
+
+// examplesForTool generates usage examples for a tool.
+func examplesForTool(toolName string) []string {
+	switch toolName {
+	case "searchSymbols":
+		return []string{`{"skill": "searchSymbols", "params": {"query": "handleAuth"}}`}
+	case "getSymbol":
+		return []string{`{"skill": "getSymbol", "params": {"symbolId": "ckb:repo:sym:abc123"}}`}
+	case "findReferences":
+		return []string{`{"skill": "findReferences", "params": {"symbolId": "ckb:repo:sym:abc123"}}`}
+	case "explore":
+		return []string{`{"skill": "explore", "params": {"target": "internal/api/", "depth": "standard"}}`}
+	case "understand":
+		return []string{`{"skill": "understand", "params": {"target": "handleAuth"}}`}
+	case "getArchitecture":
+		return []string{`{"skill": "getArchitecture", "params": {}}`}
+	case "analyzeImpact":
+		return []string{`{"skill": "analyzeImpact", "params": {"symbolId": "ckb:repo:sym:abc123"}}`}
+	case "getStatus":
+		return []string{`{"skill": "getStatus", "params": {}}`}
+	default:
+		return []string{fmt.Sprintf(`{"skill": "%s", "params": {}}`, toolName)}
+	}
+}
+

--- a/internal/a2a/streaming.go
+++ b/internal/a2a/streaming.go
@@ -1,0 +1,262 @@
+package a2a
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/SimplyLiz/CodeMCP/internal/envelope"
+	"github.com/google/uuid"
+)
+
+const (
+	sseHeartbeatInterval = 15 * time.Second
+)
+
+// handleHTTPMessageStream handles POST /message:stream — SSE streaming send.
+func (s *Server) handleHTTPMessageStream(w http.ResponseWriter, r *http.Request) {
+	var req SendMessageRequest
+	if err := decodeBody(r, &req); err != nil {
+		writeA2AError(w, NewParseError(err.Error()))
+		return
+	}
+	s.doStreamingSend(w, r, req)
+}
+
+// handleHTTPSubscribeTask handles POST /tasks/{id}:subscribe — SSE subscription.
+func (s *Server) handleHTTPSubscribeTask(w http.ResponseWriter, r *http.Request) {
+	taskID := r.PathValue("id")
+	if taskID == "" {
+		writeA2AError(w, NewInvalidParamsError("task ID required"))
+		return
+	}
+	s.doStreamSubscribe(w, r, taskID)
+}
+
+// doStreamingSend creates a task and streams execution progress via SSE.
+func (s *Server) doStreamingSend(w http.ResponseWriter, r *http.Request, req SendMessageRequest) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeA2AError(w, NewInternalError("streaming not supported"))
+		return
+	}
+
+	// Parse skill request
+	skillID, params, err := ParseSkillRequest(req.Message)
+	if err != nil {
+		writeA2AError(w, NewInvalidParamsError(err.Error()))
+		return
+	}
+	if s.skills.GetSkill(skillID) == nil {
+		writeA2AError(w, NewInvalidParamsError(fmt.Sprintf("unknown skill: %s", skillID)))
+		return
+	}
+
+	// Create task
+	contextID := req.Message.ContextID
+	task, err := s.store.CreateTask(contextID, req.Metadata)
+	if err != nil {
+		writeA2AError(w, NewInternalError(fmt.Sprintf("create task: %v", err)))
+		return
+	}
+
+	// Store user message
+	userMsg := req.Message
+	userMsg.MessageID = uuid.New().String()
+	_ = s.store.AddMessage(task.ID, userMsg)
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	// Send initial task state
+	sendSSE(w, flusher, StreamResponse{
+		Task: task,
+	})
+
+	// Transition to working
+	_ = s.store.UpdateTaskState(task.ID, TaskStateWorking, nil)
+	sendSSE(w, flusher, StreamResponse{
+		StatusUpdate: &TaskStatusUpdateEvent{
+			TaskID:    task.ID,
+			ContextID: task.ContextID,
+			Status:    TaskStatus{State: TaskStateWorking, Timestamp: nowISO()},
+		},
+	})
+
+	// Execute skill in a goroutine for heartbeat support
+	type toolResult struct {
+		resp *envelope.Response
+		err  error
+	}
+	resultCh := make(chan toolResult, 1)
+	go func() {
+		result, toolErr := s.mcpServer.CallTool(skillID, params)
+		resultCh <- toolResult{resp: result, err: toolErr}
+	}()
+
+	// Wait for result with heartbeats
+	heartbeat := time.NewTicker(sseHeartbeatInterval)
+	defer heartbeat.Stop()
+
+	var toolRes toolResult
+	waiting := true
+	for waiting {
+		select {
+		case <-r.Context().Done():
+			_ = s.store.UpdateTaskState(task.ID, TaskStateCanceled, nil)
+			return
+		case <-heartbeat.C:
+			sendSSEComment(w, flusher, "heartbeat")
+		case toolRes = <-resultCh:
+			waiting = false
+		}
+	}
+
+	if toolRes.err != nil {
+		failMsg := Message{
+			MessageID: uuid.New().String(),
+			Role:      RoleAgent,
+			Parts:     []Part{{Text: fmt.Sprintf("skill execution failed: %v", toolRes.err), MediaType: "text/plain"}},
+		}
+		_ = s.store.AddMessage(task.ID, failMsg)
+		_ = s.store.UpdateTaskState(task.ID, TaskStateFailed, &failMsg)
+		sendSSE(w, flusher, StreamResponse{
+			StatusUpdate: &TaskStatusUpdateEvent{
+				TaskID:    task.ID,
+				ContextID: task.ContextID,
+				Status:    TaskStatus{State: TaskStateFailed, Timestamp: nowISO(), Message: &failMsg},
+			},
+		})
+		finalTask, _ := s.store.GetTask(task.ID, nil)
+		if finalTask != nil {
+			sendSSE(w, flusher, StreamResponse{Task: finalTask})
+		}
+		return
+	}
+
+	// Emit artifacts
+	artifacts := EnvelopeToArtifacts(toolRes.resp, skillID)
+	for _, art := range artifacts {
+		_ = s.store.AddArtifact(task.ID, art)
+		sendSSE(w, flusher, StreamResponse{
+			ArtifactUpdate: &TaskArtifactUpdateEvent{
+				TaskID:    task.ID,
+				ContextID: task.ContextID,
+				Artifact:  art,
+			},
+		})
+	}
+
+	// Complete
+	agentMsg := EnvelopeToMessage(toolRes.resp, skillID)
+	_ = s.store.AddMessage(task.ID, agentMsg)
+	_ = s.store.UpdateTaskState(task.ID, TaskStateCompleted, &agentMsg)
+
+	sendSSE(w, flusher, StreamResponse{
+		StatusUpdate: &TaskStatusUpdateEvent{
+			TaskID:    task.ID,
+			ContextID: task.ContextID,
+			Status:    TaskStatus{State: TaskStateCompleted, Timestamp: nowISO(), Message: &agentMsg},
+		},
+	})
+
+	// Send final task object
+	finalTask, _ := s.store.GetTask(task.ID, nil)
+	if finalTask != nil {
+		sendSSE(w, flusher, StreamResponse{Task: finalTask})
+	}
+}
+
+// doStreamSubscribe subscribes to an existing task's events via SSE.
+func (s *Server) doStreamSubscribe(w http.ResponseWriter, r *http.Request, taskID string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeA2AError(w, NewInternalError("streaming not supported"))
+		return
+	}
+
+	// Verify task exists
+	task, err := s.store.GetTask(taskID, nil)
+	if err != nil || task == nil {
+		writeA2AError(w, NewTaskNotFoundError(taskID))
+		return
+	}
+
+	// If task is already terminal, just send the final state
+	if IsTerminal(task.Status.State) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		sendSSE(w, flusher, StreamResponse{Task: task})
+		return
+	}
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	// Send current task state
+	sendSSE(w, flusher, StreamResponse{Task: task})
+
+	// Subscribe to updates
+	ch := s.subscribe(taskID)
+	defer s.unsubscribe(taskID, ch)
+
+	heartbeat := time.NewTicker(sseHeartbeatInterval)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeat.C:
+			sendSSEComment(w, flusher, "heartbeat")
+		case event, ok := <-ch:
+			if !ok {
+				return // channel closed
+			}
+			sendSSE(w, flusher, event)
+
+			// If this event contains a terminal task state, close the stream
+			if event.StatusUpdate != nil && IsTerminal(event.StatusUpdate.Status.State) {
+				// Send final task
+				finalTask, _ := s.store.GetTask(taskID, nil)
+				if finalTask != nil {
+					sendSSE(w, flusher, StreamResponse{Task: finalTask})
+				}
+				return
+			}
+			if event.Task != nil && IsTerminal(event.Task.Status.State) {
+				return
+			}
+		}
+	}
+}
+
+// --- SSE helpers ---
+
+func sendSSE(w http.ResponseWriter, flusher http.Flusher, event StreamResponse) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, "data: %s\n\n", data)
+	flusher.Flush()
+}
+
+func sendSSEComment(w http.ResponseWriter, flusher http.Flusher, comment string) {
+	fmt.Fprintf(w, ": %s\n\n", comment)
+	flusher.Flush()
+}

--- a/internal/a2a/streaming.go
+++ b/internal/a2a/streaming.go
@@ -89,7 +89,11 @@ func (s *Server) doStreamingSend(w http.ResponseWriter, r *http.Request, req Sen
 		},
 	})
 
-	// Execute skill in a goroutine for heartbeat support
+	// Execute skill in a goroutine for heartbeat support.
+	// Note: MCP tool handlers don't accept context, so we can't cancel the
+	// underlying operation. But we stop waiting and mark the task canceled
+	// so the client isn't left hanging, and the goroutine drains into a
+	// buffered channel (no leak).
 	type toolResult struct {
 		resp *envelope.Response
 		err  error
@@ -100,7 +104,6 @@ func (s *Server) doStreamingSend(w http.ResponseWriter, r *http.Request, req Sen
 		resultCh <- toolResult{resp: result, err: toolErr}
 	}()
 
-	// Wait for result with heartbeats
 	heartbeat := time.NewTicker(sseHeartbeatInterval)
 	defer heartbeat.Stop()
 
@@ -109,7 +112,23 @@ func (s *Server) doStreamingSend(w http.ResponseWriter, r *http.Request, req Sen
 	for waiting {
 		select {
 		case <-r.Context().Done():
-			_ = s.store.UpdateTaskState(task.ID, TaskStateCanceled, nil)
+			// Client disconnected — cancel the task and stop streaming.
+			// The goroutine will complete in the background and write to the
+			// buffered channel (no leak), but we don't wait for it.
+			cancelMsg := Message{
+				MessageID: uuid.New().String(),
+				Role:      RoleAgent,
+				Parts:     []Part{{Text: "client disconnected", MediaType: "text/plain"}},
+			}
+			_ = s.store.AddMessage(task.ID, cancelMsg)
+			_ = s.store.UpdateTaskState(task.ID, TaskStateCanceled, &cancelMsg)
+			s.notify(task.ID, StreamResponse{
+				StatusUpdate: &TaskStatusUpdateEvent{
+					TaskID:    task.ID,
+					ContextID: task.ContextID,
+					Status:    TaskStatus{State: TaskStateCanceled, Timestamp: nowISO(), Message: &cancelMsg},
+				},
+			})
 			return
 		case <-heartbeat.C:
 			sendSSEComment(w, flusher, "heartbeat")

--- a/internal/a2a/task_state.go
+++ b/internal/a2a/task_state.go
@@ -1,0 +1,41 @@
+package a2a
+
+// validTransitions defines the allowed state transitions per the A2A spec.
+var validTransitions = map[TaskState][]TaskState{
+	TaskStateSubmitted:     {TaskStateWorking, TaskStateRejected, TaskStateCanceled},
+	TaskStateWorking:       {TaskStateCompleted, TaskStateFailed, TaskStateInputRequired, TaskStateAuthRequired, TaskStateCanceled},
+	TaskStateInputRequired: {TaskStateWorking, TaskStateCanceled, TaskStateFailed},
+	TaskStateAuthRequired:  {TaskStateWorking, TaskStateCanceled, TaskStateFailed},
+}
+
+// terminalStates are states with no outgoing transitions.
+var terminalStates = map[TaskState]bool{
+	TaskStateCompleted: true,
+	TaskStateFailed:    true,
+	TaskStateCanceled:  true,
+	TaskStateRejected:  true,
+}
+
+// ValidTransition returns true if transitioning from -> to is allowed.
+func ValidTransition(from, to TaskState) bool {
+	allowed, ok := validTransitions[from]
+	if !ok {
+		return false
+	}
+	for _, s := range allowed {
+		if s == to {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTerminal returns true if the state is a terminal (final) state.
+func IsTerminal(state TaskState) bool {
+	return terminalStates[state]
+}
+
+// CanCancel returns true if a task in the given state can be canceled.
+func CanCancel(state TaskState) bool {
+	return ValidTransition(state, TaskStateCanceled)
+}

--- a/internal/a2a/task_state_test.go
+++ b/internal/a2a/task_state_test.go
@@ -1,0 +1,83 @@
+package a2a
+
+import "testing"
+
+func TestValidTransitions(t *testing.T) {
+	tests := []struct {
+		from  TaskState
+		to    TaskState
+		valid bool
+	}{
+		// submitted ->
+		{TaskStateSubmitted, TaskStateWorking, true},
+		{TaskStateSubmitted, TaskStateRejected, true},
+		{TaskStateSubmitted, TaskStateCanceled, true},
+		{TaskStateSubmitted, TaskStateCompleted, false},
+		{TaskStateSubmitted, TaskStateFailed, false},
+
+		// working ->
+		{TaskStateWorking, TaskStateCompleted, true},
+		{TaskStateWorking, TaskStateFailed, true},
+		{TaskStateWorking, TaskStateInputRequired, true},
+		{TaskStateWorking, TaskStateAuthRequired, true},
+		{TaskStateWorking, TaskStateCanceled, true},
+		{TaskStateWorking, TaskStateSubmitted, false},
+
+		// input-required ->
+		{TaskStateInputRequired, TaskStateWorking, true},
+		{TaskStateInputRequired, TaskStateCanceled, true},
+		{TaskStateInputRequired, TaskStateFailed, true},
+		{TaskStateInputRequired, TaskStateCompleted, false},
+
+		// auth-required ->
+		{TaskStateAuthRequired, TaskStateWorking, true},
+		{TaskStateAuthRequired, TaskStateCanceled, true},
+		{TaskStateAuthRequired, TaskStateFailed, true},
+		{TaskStateAuthRequired, TaskStateCompleted, false},
+
+		// terminal states have no outgoing transitions
+		{TaskStateCompleted, TaskStateWorking, false},
+		{TaskStateFailed, TaskStateWorking, false},
+		{TaskStateCanceled, TaskStateWorking, false},
+		{TaskStateRejected, TaskStateWorking, false},
+	}
+
+	for _, tt := range tests {
+		result := ValidTransition(tt.from, tt.to)
+		if result != tt.valid {
+			t.Errorf("ValidTransition(%s, %s) = %v, want %v", tt.from, tt.to, result, tt.valid)
+		}
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	terminal := []TaskState{TaskStateCompleted, TaskStateFailed, TaskStateCanceled, TaskStateRejected}
+	nonTerminal := []TaskState{TaskStateSubmitted, TaskStateWorking, TaskStateInputRequired, TaskStateAuthRequired}
+
+	for _, s := range terminal {
+		if !IsTerminal(s) {
+			t.Errorf("IsTerminal(%s) = false, want true", s)
+		}
+	}
+	for _, s := range nonTerminal {
+		if IsTerminal(s) {
+			t.Errorf("IsTerminal(%s) = true, want false", s)
+		}
+	}
+}
+
+func TestCanCancel(t *testing.T) {
+	cancelable := []TaskState{TaskStateSubmitted, TaskStateWorking, TaskStateInputRequired, TaskStateAuthRequired}
+	notCancelable := []TaskState{TaskStateCompleted, TaskStateFailed, TaskStateCanceled, TaskStateRejected}
+
+	for _, s := range cancelable {
+		if !CanCancel(s) {
+			t.Errorf("CanCancel(%s) = false, want true", s)
+		}
+	}
+	for _, s := range notCancelable {
+		if CanCancel(s) {
+			t.Errorf("CanCancel(%s) = true, want false", s)
+		}
+	}
+}

--- a/internal/a2a/task_store.go
+++ b/internal/a2a/task_store.go
@@ -1,0 +1,635 @@
+package a2a
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	_ "modernc.org/sqlite"
+)
+
+// TaskStore provides SQLite-backed persistence for A2A tasks.
+type TaskStore struct {
+	conn   *sql.DB
+	logger *slog.Logger
+	dbPath string
+}
+
+// OpenTaskStore opens or creates the A2A task database at .ckb/a2a_tasks.db.
+func OpenTaskStore(ckbDir string, logger *slog.Logger) (*TaskStore, error) {
+	if err := os.MkdirAll(ckbDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create .ckb directory: %w", err)
+	}
+
+	dbPath := filepath.Join(ckbDir, "a2a_tasks.db")
+	conn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open A2A task database: %w", err)
+	}
+
+	pragmas := []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA synchronous=NORMAL",
+		"PRAGMA foreign_keys=ON",
+		"PRAGMA busy_timeout=5000",
+		"PRAGMA cache_size=-16000",
+	}
+	for _, p := range pragmas {
+		if _, err := conn.Exec(p); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("failed to set pragma: %w", err)
+		}
+	}
+
+	store := &TaskStore{conn: conn, logger: logger, dbPath: dbPath}
+	if err := store.initSchema(); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to initialize schema: %w", err)
+	}
+	return store, nil
+}
+
+// Close closes the database connection.
+func (s *TaskStore) Close() error {
+	return s.conn.Close()
+}
+
+func (s *TaskStore) initSchema() error {
+	schema := `
+	CREATE TABLE IF NOT EXISTS tasks (
+		id TEXT PRIMARY KEY,
+		context_id TEXT NOT NULL DEFAULT '',
+		state TEXT NOT NULL DEFAULT 'TASK_STATE_SUBMITTED',
+		status_message TEXT,
+		metadata TEXT,
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_tasks_state ON tasks(state);
+	CREATE INDEX IF NOT EXISTS idx_tasks_context ON tasks(context_id);
+	CREATE INDEX IF NOT EXISTS idx_tasks_updated ON tasks(updated_at DESC);
+
+	CREATE TABLE IF NOT EXISTS task_messages (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+		message_id TEXT NOT NULL DEFAULT '',
+		role TEXT NOT NULL,
+		parts TEXT NOT NULL,
+		metadata TEXT,
+		created_at TEXT NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_messages_task ON task_messages(task_id);
+
+	CREATE TABLE IF NOT EXISTS task_artifacts (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+		artifact_id TEXT NOT NULL,
+		name TEXT NOT NULL DEFAULT '',
+		description TEXT NOT NULL DEFAULT '',
+		parts TEXT NOT NULL,
+		metadata TEXT,
+		created_at TEXT NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_artifacts_task ON task_artifacts(task_id);
+
+	CREATE TABLE IF NOT EXISTS push_notification_configs (
+		id TEXT PRIMARY KEY,
+		task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+		url TEXT NOT NULL,
+		auth_schemes TEXT,
+		auth_token TEXT NOT NULL DEFAULT '',
+		created_at TEXT NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_push_task ON push_notification_configs(task_id);
+
+	CREATE TABLE IF NOT EXISTS task_status_history (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+		state TEXT NOT NULL,
+		message TEXT,
+		timestamp TEXT NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_status_history_task ON task_status_history(task_id);
+	`
+	_, err := s.conn.Exec(schema)
+	return err
+}
+
+// --- Task CRUD ---
+
+// CreateTask creates a new task and returns it.
+func (s *TaskStore) CreateTask(contextID string, metadata map[string]any) (*Task, error) {
+	id := uuid.New().String()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	if contextID == "" {
+		contextID = uuid.New().String()
+	}
+
+	var metaJSON sql.NullString
+	if metadata != nil {
+		b, err := json.Marshal(metadata)
+		if err != nil {
+			return nil, fmt.Errorf("marshal metadata: %w", err)
+		}
+		metaJSON = sql.NullString{String: string(b), Valid: true}
+	}
+
+	_, err := s.conn.Exec(
+		`INSERT INTO tasks (id, context_id, state, created_at, updated_at, metadata) VALUES (?, ?, ?, ?, ?, ?)`,
+		id, contextID, string(TaskStateSubmitted), now, now, metaJSON,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert task: %w", err)
+	}
+
+	// Record initial status
+	_, _ = s.conn.Exec(
+		`INSERT INTO task_status_history (task_id, state, timestamp) VALUES (?, ?, ?)`,
+		id, string(TaskStateSubmitted), now,
+	)
+
+	return &Task{
+		ID:        id,
+		ContextID: contextID,
+		Status: TaskStatus{
+			State:     TaskStateSubmitted,
+			Timestamp: now,
+		},
+		Metadata: metadata,
+	}, nil
+}
+
+// GetTask retrieves a task by ID with optional history length.
+func (s *TaskStore) GetTask(taskID string, historyLength *int) (*Task, error) {
+	var (
+		state         string
+		contextID     string
+		statusMessage sql.NullString
+		metadataJSON  sql.NullString
+		updatedAt     string
+	)
+
+	err := s.conn.QueryRow(
+		`SELECT state, context_id, status_message, metadata, updated_at FROM tasks WHERE id = ?`,
+		taskID,
+	).Scan(&state, &contextID, &statusMessage, &metadataJSON, &updatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query task: %w", err)
+	}
+
+	task := &Task{
+		ID:        taskID,
+		ContextID: contextID,
+		Status: TaskStatus{
+			State:     TaskState(state),
+			Timestamp: updatedAt,
+		},
+	}
+
+	if statusMessage.Valid {
+		var msg Message
+		if json.Unmarshal([]byte(statusMessage.String), &msg) == nil {
+			task.Status.Message = &msg
+		}
+	}
+
+	if metadataJSON.Valid {
+		var meta map[string]any
+		if json.Unmarshal([]byte(metadataJSON.String), &meta) == nil {
+			task.Metadata = meta
+		}
+	}
+
+	// Load history
+	if historyLength == nil || *historyLength != 0 {
+		messages, err := s.getMessages(taskID, historyLength)
+		if err != nil {
+			return nil, err
+		}
+		task.History = messages
+	}
+
+	// Load artifacts
+	artifacts, err := s.getArtifacts(taskID)
+	if err != nil {
+		return nil, err
+	}
+	task.Artifacts = artifacts
+
+	return task, nil
+}
+
+// UpdateTaskState transitions a task to a new state.
+func (s *TaskStore) UpdateTaskState(taskID string, newState TaskState, statusMsg *Message) error {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	var currentState string
+	err := s.conn.QueryRow(`SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&currentState)
+	if err == sql.ErrNoRows {
+		return NewTaskNotFoundError(taskID)
+	}
+	if err != nil {
+		return fmt.Errorf("query task state: %w", err)
+	}
+
+	if !ValidTransition(TaskState(currentState), newState) {
+		return fmt.Errorf("invalid state transition: %s -> %s", currentState, string(newState))
+	}
+
+	var statusMsgJSON sql.NullString
+	if statusMsg != nil {
+		b, err := json.Marshal(statusMsg)
+		if err != nil {
+			return fmt.Errorf("marshal status message: %w", err)
+		}
+		statusMsgJSON = sql.NullString{String: string(b), Valid: true}
+	}
+
+	_, err = s.conn.Exec(
+		`UPDATE tasks SET state = ?, status_message = ?, updated_at = ? WHERE id = ?`,
+		string(newState), statusMsgJSON, now, taskID,
+	)
+	if err != nil {
+		return fmt.Errorf("update task state: %w", err)
+	}
+
+	// Record state transition
+	var historyMsg sql.NullString
+	if statusMsg != nil {
+		historyMsg = statusMsgJSON
+	}
+	_, _ = s.conn.Exec(
+		`INSERT INTO task_status_history (task_id, state, message, timestamp) VALUES (?, ?, ?, ?)`,
+		taskID, string(newState), historyMsg, now,
+	)
+
+	return nil
+}
+
+// AddMessage adds a message to a task's history.
+func (s *TaskStore) AddMessage(taskID string, msg Message) error {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	partsJSON, err := json.Marshal(msg.Parts)
+	if err != nil {
+		return fmt.Errorf("marshal parts: %w", err)
+	}
+
+	var metaJSON sql.NullString
+	if msg.Metadata != nil {
+		b, err := json.Marshal(msg.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal metadata: %w", err)
+		}
+		metaJSON = sql.NullString{String: string(b), Valid: true}
+	}
+
+	msgID := msg.MessageID
+	if msgID == "" {
+		msgID = uuid.New().String()
+	}
+
+	_, err = s.conn.Exec(
+		`INSERT INTO task_messages (task_id, message_id, role, parts, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		taskID, msgID, string(msg.Role), string(partsJSON), metaJSON, now,
+	)
+	if err != nil {
+		return fmt.Errorf("insert message: %w", err)
+	}
+	return nil
+}
+
+// AddArtifact adds an artifact to a task.
+func (s *TaskStore) AddArtifact(taskID string, artifact Artifact) error {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	partsJSON, err := json.Marshal(artifact.Parts)
+	if err != nil {
+		return fmt.Errorf("marshal artifact parts: %w", err)
+	}
+
+	var metaJSON sql.NullString
+	if artifact.Metadata != nil {
+		b, err := json.Marshal(artifact.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal metadata: %w", err)
+		}
+		metaJSON = sql.NullString{String: string(b), Valid: true}
+	}
+
+	artifactID := artifact.ArtifactID
+	if artifactID == "" {
+		artifactID = uuid.New().String()
+	}
+
+	_, err = s.conn.Exec(
+		`INSERT INTO task_artifacts (task_id, artifact_id, name, description, parts, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		taskID, artifactID, artifact.Name, artifact.Name, string(partsJSON), metaJSON, now,
+	)
+	if err != nil {
+		return fmt.Errorf("insert artifact: %w", err)
+	}
+	return nil
+}
+
+// ListTasks returns tasks with cursor-based pagination.
+func (s *TaskStore) ListTasks(req ListTasksRequest) (*ListTasksResponse, error) {
+	pageSize := req.PageSize
+	if pageSize <= 0 {
+		pageSize = DefaultPageSize
+	}
+	if pageSize > MaxPageSize {
+		pageSize = MaxPageSize
+	}
+
+	// Build query
+	where := []string{"1=1"}
+	args := []any{}
+
+	if req.ContextID != "" {
+		where = append(where, "context_id = ?")
+		args = append(args, req.ContextID)
+	}
+	if req.Status != nil {
+		where = append(where, "state = ?")
+		args = append(args, string(*req.Status))
+	}
+
+	// Cursor: base64-encoded offset
+	offset := 0
+	if req.PageToken != "" {
+		decoded, err := base64.StdEncoding.DecodeString(req.PageToken)
+		if err == nil {
+			offset, _ = strconv.Atoi(string(decoded))
+		}
+	}
+
+	// Count total
+	var totalSize int
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM tasks WHERE %s", joinAnd(where))
+	_ = s.conn.QueryRow(countQuery, args...).Scan(&totalSize)
+
+	// Fetch page
+	query := fmt.Sprintf(
+		"SELECT id FROM tasks WHERE %s ORDER BY updated_at DESC LIMIT ? OFFSET ?",
+		joinAnd(where),
+	)
+	args = append(args, pageSize, offset)
+	rows, err := s.conn.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list tasks: %w", err)
+	}
+	defer rows.Close()
+
+	var tasks []Task
+	for rows.Next() {
+		var taskID string
+		if err := rows.Scan(&taskID); err != nil {
+			continue
+		}
+		task, err := s.GetTask(taskID, req.HistoryLength)
+		if err != nil || task == nil {
+			continue
+		}
+		if !req.IncludeArtifacts {
+			task.Artifacts = nil
+		}
+		tasks = append(tasks, *task)
+	}
+
+	resp := &ListTasksResponse{
+		Tasks:     tasks,
+		TotalSize: totalSize,
+		PageSize:  pageSize,
+	}
+
+	if offset+pageSize < totalSize {
+		nextOffset := offset + pageSize
+		resp.NextPageToken = base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(nextOffset)))
+	}
+
+	return resp, nil
+}
+
+// --- Push Notification Config ---
+
+// CreatePushConfig creates a push notification config for a task.
+func (s *TaskStore) CreatePushConfig(taskID string, cfg PushNotificationConfig) (*PushNotificationConfig, error) {
+	id := uuid.New().String()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	var authSchemes sql.NullString
+	var authToken string
+	if cfg.Authentication != nil {
+		if len(cfg.Authentication.Schemes) > 0 {
+			b, _ := json.Marshal(cfg.Authentication.Schemes)
+			authSchemes = sql.NullString{String: string(b), Valid: true}
+		}
+		authToken = cfg.Authentication.Token
+	}
+
+	_, err := s.conn.Exec(
+		`INSERT INTO push_notification_configs (id, task_id, url, auth_schemes, auth_token, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		id, taskID, cfg.URL, authSchemes, authToken, now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert push config: %w", err)
+	}
+
+	return &PushNotificationConfig{
+		ID:             id,
+		URL:            cfg.URL,
+		TaskID:         taskID,
+		Authentication: cfg.Authentication,
+	}, nil
+}
+
+// GetPushConfig retrieves a push notification config by ID.
+func (s *TaskStore) GetPushConfig(configID string) (*PushNotificationConfig, error) {
+	var (
+		taskID      string
+		url         string
+		authSchemes sql.NullString
+		authToken   string
+	)
+	err := s.conn.QueryRow(
+		`SELECT task_id, url, auth_schemes, auth_token FROM push_notification_configs WHERE id = ?`,
+		configID,
+	).Scan(&taskID, &url, &authSchemes, &authToken)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query push config: %w", err)
+	}
+
+	cfg := &PushNotificationConfig{
+		ID:     configID,
+		URL:    url,
+		TaskID: taskID,
+	}
+	if authToken != "" || authSchemes.Valid {
+		cfg.Authentication = &AuthenticationInfo{Token: authToken}
+		if authSchemes.Valid {
+			_ = json.Unmarshal([]byte(authSchemes.String), &cfg.Authentication.Schemes)
+		}
+	}
+	return cfg, nil
+}
+
+// ListPushConfigs lists push notification configs for a task.
+func (s *TaskStore) ListPushConfigs(taskID string) ([]PushNotificationConfig, error) {
+	rows, err := s.conn.Query(
+		`SELECT id, url, auth_schemes, auth_token FROM push_notification_configs WHERE task_id = ?`,
+		taskID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list push configs: %w", err)
+	}
+	defer rows.Close()
+
+	var configs []PushNotificationConfig
+	for rows.Next() {
+		var (
+			id          string
+			url         string
+			authSchemes sql.NullString
+			authToken   string
+		)
+		if err := rows.Scan(&id, &url, &authSchemes, &authToken); err != nil {
+			continue
+		}
+		cfg := PushNotificationConfig{ID: id, URL: url, TaskID: taskID}
+		if authToken != "" || authSchemes.Valid {
+			cfg.Authentication = &AuthenticationInfo{Token: authToken}
+			if authSchemes.Valid {
+				_ = json.Unmarshal([]byte(authSchemes.String), &cfg.Authentication.Schemes)
+			}
+		}
+		configs = append(configs, cfg)
+	}
+	return configs, nil
+}
+
+// DeletePushConfig deletes a push notification config.
+func (s *TaskStore) DeletePushConfig(configID string) error {
+	result, err := s.conn.Exec(`DELETE FROM push_notification_configs WHERE id = ?`, configID)
+	if err != nil {
+		return fmt.Errorf("delete push config: %w", err)
+	}
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		return fmt.Errorf("push config not found: %s", configID)
+	}
+	return nil
+}
+
+// CleanupOldTasks removes completed/failed/canceled tasks older than the given duration.
+func (s *TaskStore) CleanupOldTasks(retention time.Duration) (int64, error) {
+	cutoff := time.Now().UTC().Add(-retention).Format(time.RFC3339Nano)
+	result, err := s.conn.Exec(
+		`DELETE FROM tasks WHERE state IN (?, ?, ?, ?) AND updated_at < ?`,
+		string(TaskStateCompleted), string(TaskStateFailed), string(TaskStateCanceled), string(TaskStateRejected), cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("cleanup old tasks: %w", err)
+	}
+	return result.RowsAffected()
+}
+
+// --- Internal helpers ---
+
+func (s *TaskStore) getMessages(taskID string, limit *int) ([]Message, error) {
+	query := `SELECT message_id, role, parts, metadata FROM task_messages WHERE task_id = ? ORDER BY id ASC`
+	args := []any{taskID}
+	if limit != nil && *limit > 0 {
+		query = `SELECT message_id, role, parts, metadata FROM task_messages WHERE task_id = ? ORDER BY id DESC LIMIT ?`
+		args = append(args, *limit)
+	}
+
+	rows, err := s.conn.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query messages: %w", err)
+	}
+	defer rows.Close()
+
+	var messages []Message
+	for rows.Next() {
+		var (
+			msgID     string
+			role      string
+			partsJSON string
+			metaJSON  sql.NullString
+		)
+		if err := rows.Scan(&msgID, &role, &partsJSON, &metaJSON); err != nil {
+			continue
+		}
+		msg := Message{MessageID: msgID, Role: Role(role)}
+		_ = json.Unmarshal([]byte(partsJSON), &msg.Parts)
+		if metaJSON.Valid {
+			_ = json.Unmarshal([]byte(metaJSON.String), &msg.Metadata)
+		}
+		messages = append(messages, msg)
+	}
+
+	// If we used DESC LIMIT, reverse to get chronological order
+	if limit != nil && *limit > 0 {
+		for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
+			messages[i], messages[j] = messages[j], messages[i]
+		}
+	}
+
+	return messages, nil
+}
+
+func (s *TaskStore) getArtifacts(taskID string) ([]Artifact, error) {
+	rows, err := s.conn.Query(
+		`SELECT artifact_id, name, description, parts, metadata FROM task_artifacts WHERE task_id = ? ORDER BY id ASC`,
+		taskID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query artifacts: %w", err)
+	}
+	defer rows.Close()
+
+	var artifacts []Artifact
+	for rows.Next() {
+		var (
+			artID       string
+			name        string
+			description string
+			partsJSON   string
+			metaJSON    sql.NullString
+		)
+		if err := rows.Scan(&artID, &name, &description, &partsJSON, &metaJSON); err != nil {
+			continue
+		}
+		art := Artifact{ArtifactID: artID, Name: name}
+		_ = json.Unmarshal([]byte(partsJSON), &art.Parts)
+		if metaJSON.Valid {
+			_ = json.Unmarshal([]byte(metaJSON.String), &art.Metadata)
+		}
+		artifacts = append(artifacts, art)
+	}
+
+	return artifacts, nil
+}
+
+func joinAnd(clauses []string) string {
+	result := clauses[0]
+	for i := 1; i < len(clauses); i++ {
+		result += " AND " + clauses[i]
+	}
+	return result
+}

--- a/internal/a2a/task_store.go
+++ b/internal/a2a/task_store.go
@@ -42,14 +42,14 @@ func OpenTaskStore(ckbDir string, logger *slog.Logger) (*TaskStore, error) {
 		"PRAGMA cache_size=-16000",
 	}
 	for _, p := range pragmas {
-		if _, err := conn.Exec(p); err != nil {
+		if _, err = conn.Exec(p); err != nil {
 			_ = conn.Close()
 			return nil, fmt.Errorf("failed to set pragma: %w", err)
 		}
 	}
 
 	store := &TaskStore{conn: conn, logger: logger, dbPath: dbPath}
-	if err := store.initSchema(); err != nil {
+	if err = store.initSchema(); err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("failed to initialize schema: %w", err)
 	}
@@ -213,7 +213,8 @@ func (s *TaskStore) GetTask(taskID string, historyLength *int) (*Task, error) {
 
 	// Load history
 	if historyLength == nil || *historyLength != 0 {
-		messages, err := s.getMessages(taskID, historyLength)
+		var messages []Message
+		messages, err = s.getMessages(taskID, historyLength)
 		if err != nil {
 			return nil, err
 		}
@@ -221,7 +222,8 @@ func (s *TaskStore) GetTask(taskID string, historyLength *int) (*Task, error) {
 	}
 
 	// Load artifacts
-	artifacts, err := s.getArtifacts(taskID)
+	var artifacts []Artifact
+	artifacts, err = s.getArtifacts(taskID)
 	if err != nil {
 		return nil, err
 	}
@@ -230,21 +232,16 @@ func (s *TaskStore) GetTask(taskID string, historyLength *int) (*Task, error) {
 	return task, nil
 }
 
-// UpdateTaskState transitions a task to a new state.
+// UpdateTaskState atomically transitions a task to a new state.
+// Uses a conditional UPDATE to prevent TOCTOU races — the UPDATE only succeeds
+// if the current state is one that allows the requested transition.
 func (s *TaskStore) UpdateTaskState(taskID string, newState TaskState, statusMsg *Message) error {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	var currentState string
-	err := s.conn.QueryRow(`SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&currentState)
-	if err == sql.ErrNoRows {
-		return NewTaskNotFoundError(taskID)
-	}
-	if err != nil {
-		return fmt.Errorf("query task state: %w", err)
-	}
-
-	if !ValidTransition(TaskState(currentState), newState) {
-		return fmt.Errorf("invalid state transition: %s -> %s", currentState, string(newState))
+	// Build the list of states that can transition to newState
+	validFrom := validSourceStates(newState)
+	if len(validFrom) == 0 {
+		return fmt.Errorf("no valid source states for target state: %s", newState)
 	}
 
 	var statusMsgJSON sql.NullString
@@ -256,15 +253,35 @@ func (s *TaskStore) UpdateTaskState(taskID string, newState TaskState, statusMsg
 		statusMsgJSON = sql.NullString{String: string(b), Valid: true}
 	}
 
-	_, err = s.conn.Exec(
-		`UPDATE tasks SET state = ?, status_message = ?, updated_at = ? WHERE id = ?`,
-		string(newState), statusMsgJSON, now, taskID,
+	// Atomic conditional update: only succeeds if current state allows this transition
+	placeholders := make([]string, len(validFrom))
+	args := []any{string(newState), statusMsgJSON, now, taskID}
+	for i, s := range validFrom {
+		placeholders[i] = "?"
+		args = append(args, string(s))
+	}
+
+	query := fmt.Sprintf(
+		`UPDATE tasks SET state = ?, status_message = ?, updated_at = ? WHERE id = ? AND state IN (%s)`,
+		joinComma(placeholders),
 	)
+	result, err := s.conn.Exec(query, args...)
 	if err != nil {
 		return fmt.Errorf("update task state: %w", err)
 	}
 
-	// Record state transition
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		// Distinguish "not found" from "invalid transition"
+		var currentState string
+		scanErr := s.conn.QueryRow(`SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&currentState)
+		if scanErr == sql.ErrNoRows {
+			return NewTaskNotFoundError(taskID)
+		}
+		return fmt.Errorf("invalid state transition: %s -> %s", currentState, string(newState))
+	}
+
+	// Record state transition in history
 	var historyMsg sql.NullString
 	if statusMsg != nil {
 		historyMsg = statusMsgJSON
@@ -288,7 +305,8 @@ func (s *TaskStore) AddMessage(taskID string, msg Message) error {
 
 	var metaJSON sql.NullString
 	if msg.Metadata != nil {
-		b, err := json.Marshal(msg.Metadata)
+		var b []byte
+		b, err = json.Marshal(msg.Metadata)
 		if err != nil {
 			return fmt.Errorf("marshal metadata: %w", err)
 		}
@@ -321,7 +339,8 @@ func (s *TaskStore) AddArtifact(taskID string, artifact Artifact) error {
 
 	var metaJSON sql.NullString
 	if artifact.Metadata != nil {
-		b, err := json.Marshal(artifact.Metadata)
+		var b []byte
+		b, err = json.Marshal(artifact.Metadata)
 		if err != nil {
 			return fmt.Errorf("marshal metadata: %w", err)
 		}
@@ -395,10 +414,11 @@ func (s *TaskStore) ListTasks(req ListTasksRequest) (*ListTasksResponse, error) 
 	var tasks []Task
 	for rows.Next() {
 		var taskID string
-		if err := rows.Scan(&taskID); err != nil {
+		if err = rows.Scan(&taskID); err != nil {
 			continue
 		}
-		task, err := s.GetTask(taskID, req.HistoryLength)
+		var task *Task
+		task, err = s.GetTask(taskID, req.HistoryLength)
 		if err != nil || task == nil {
 			continue
 		}
@@ -507,7 +527,7 @@ func (s *TaskStore) ListPushConfigs(taskID string) ([]PushNotificationConfig, er
 			authSchemes sql.NullString
 			authToken   string
 		)
-		if err := rows.Scan(&id, &url, &authSchemes, &authToken); err != nil {
+		if err = rows.Scan(&id, &url, &authSchemes, &authToken); err != nil {
 			continue
 		}
 		cfg := PushNotificationConfig{ID: id, URL: url, TaskID: taskID}
@@ -572,7 +592,7 @@ func (s *TaskStore) getMessages(taskID string, limit *int) ([]Message, error) {
 			partsJSON string
 			metaJSON  sql.NullString
 		)
-		if err := rows.Scan(&msgID, &role, &partsJSON, &metaJSON); err != nil {
+		if err = rows.Scan(&msgID, &role, &partsJSON, &metaJSON); err != nil {
 			continue
 		}
 		msg := Message{MessageID: msgID, Role: Role(role)}
@@ -612,7 +632,7 @@ func (s *TaskStore) getArtifacts(taskID string) ([]Artifact, error) {
 			partsJSON   string
 			metaJSON    sql.NullString
 		)
-		if err := rows.Scan(&artID, &name, &description, &partsJSON, &metaJSON); err != nil {
+		if err = rows.Scan(&artID, &name, &description, &partsJSON, &metaJSON); err != nil {
 			continue
 		}
 		art := Artifact{ArtifactID: artID, Name: name}
@@ -632,4 +652,26 @@ func joinAnd(clauses []string) string {
 		result += " AND " + clauses[i]
 	}
 	return result
+}
+
+func joinComma(parts []string) string {
+	result := parts[0]
+	for i := 1; i < len(parts); i++ {
+		result += ", " + parts[i]
+	}
+	return result
+}
+
+// validSourceStates returns all states that can transition to the given target state.
+func validSourceStates(target TaskState) []TaskState {
+	var sources []TaskState
+	for from, tos := range validTransitions {
+		for _, to := range tos {
+			if to == target {
+				sources = append(sources, from)
+				break
+			}
+		}
+	}
+	return sources
 }

--- a/internal/a2a/task_store_test.go
+++ b/internal/a2a/task_store_test.go
@@ -1,0 +1,311 @@
+package a2a
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+func setupTestStore(t *testing.T) *TaskStore {
+	t.Helper()
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	store, err := OpenTaskStore(dir, logger)
+	if err != nil {
+		t.Fatalf("OpenTaskStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestCreateAndGetTask(t *testing.T) {
+	store := setupTestStore(t)
+
+	task, err := store.CreateTask("ctx-1", map[string]any{"key": "value"})
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if task.ID == "" {
+		t.Fatal("task ID should not be empty")
+	}
+	if task.ContextID != "ctx-1" {
+		t.Errorf("contextId = %s, want ctx-1", task.ContextID)
+	}
+	if task.Status.State != TaskStateSubmitted {
+		t.Errorf("state = %s, want %s", task.Status.State, TaskStateSubmitted)
+	}
+
+	// Retrieve
+	got, err := store.GetTask(task.ID, nil)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetTask returned nil")
+	}
+	if got.ID != task.ID {
+		t.Errorf("ID = %s, want %s", got.ID, task.ID)
+	}
+	if got.Metadata["key"] != "value" {
+		t.Errorf("metadata key = %v, want value", got.Metadata["key"])
+	}
+}
+
+func TestCreateTaskAutoContextID(t *testing.T) {
+	store := setupTestStore(t)
+
+	task, err := store.CreateTask("", nil)
+	if err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if task.ContextID == "" {
+		t.Error("auto-generated contextId should not be empty")
+	}
+}
+
+func TestUpdateTaskState(t *testing.T) {
+	store := setupTestStore(t)
+
+	task, _ := store.CreateTask("", nil)
+
+	// submitted -> working
+	err := store.UpdateTaskState(task.ID, TaskStateWorking, nil)
+	if err != nil {
+		t.Fatalf("UpdateTaskState to working: %v", err)
+	}
+
+	got, _ := store.GetTask(task.ID, nil)
+	if got.Status.State != TaskStateWorking {
+		t.Errorf("state = %s, want %s", got.Status.State, TaskStateWorking)
+	}
+
+	// working -> completed
+	msg := &Message{Role: RoleAgent, Parts: []Part{{Text: "done"}}}
+	err = store.UpdateTaskState(task.ID, TaskStateCompleted, msg)
+	if err != nil {
+		t.Fatalf("UpdateTaskState to completed: %v", err)
+	}
+
+	got, _ = store.GetTask(task.ID, nil)
+	if got.Status.State != TaskStateCompleted {
+		t.Errorf("state = %s, want %s", got.Status.State, TaskStateCompleted)
+	}
+}
+
+func TestUpdateTaskStateInvalidTransition(t *testing.T) {
+	store := setupTestStore(t)
+
+	task, _ := store.CreateTask("", nil)
+
+	// submitted -> completed (invalid)
+	err := store.UpdateTaskState(task.ID, TaskStateCompleted, nil)
+	if err == nil {
+		t.Error("expected error for invalid transition submitted -> completed")
+	}
+}
+
+func TestUpdateTaskStateNotFound(t *testing.T) {
+	store := setupTestStore(t)
+
+	err := store.UpdateTaskState("nonexistent", TaskStateWorking, nil)
+	if err == nil {
+		t.Error("expected error for nonexistent task")
+	}
+}
+
+func TestAddAndGetMessages(t *testing.T) {
+	store := setupTestStore(t)
+
+	task, _ := store.CreateTask("", nil)
+
+	msg1 := Message{Role: RoleUser, Parts: []Part{{Text: "hello"}}}
+	msg2 := Message{Role: RoleAgent, Parts: []Part{{Text: "world"}}}
+
+	if err := store.AddMessage(task.ID, msg1); err != nil {
+		t.Fatalf("AddMessage 1: %v", err)
+	}
+	if err := store.AddMessage(task.ID, msg2); err != nil {
+		t.Fatalf("AddMessage 2: %v", err)
+	}
+
+	got, _ := store.GetTask(task.ID, nil)
+	if len(got.History) != 2 {
+		t.Fatalf("history length = %d, want 2", len(got.History))
+	}
+	if got.History[0].Role != RoleUser {
+		t.Errorf("msg[0] role = %s, want %s", got.History[0].Role, RoleUser)
+	}
+	if got.History[1].Role != RoleAgent {
+		t.Errorf("msg[1] role = %s, want %s", got.History[1].Role, RoleAgent)
+	}
+
+	// Test history limit
+	limit := 1
+	got, _ = store.GetTask(task.ID, &limit)
+	if len(got.History) != 1 {
+		t.Errorf("history with limit=1 length = %d, want 1", len(got.History))
+	}
+	// Should get the most recent message
+	if got.History[0].Role != RoleAgent {
+		t.Errorf("limited msg[0] role = %s, want %s (most recent)", got.History[0].Role, RoleAgent)
+	}
+}
+
+func TestAddAndGetArtifacts(t *testing.T) {
+	store := setupTestStore(t)
+
+	task, _ := store.CreateTask("", nil)
+
+	art := Artifact{
+		ArtifactID: "art-1",
+		Name:       "test-result",
+		Parts:      []Part{{Text: `{"data": true}`, MediaType: "application/json"}},
+	}
+	if err := store.AddArtifact(task.ID, art); err != nil {
+		t.Fatalf("AddArtifact: %v", err)
+	}
+
+	got, _ := store.GetTask(task.ID, nil)
+	if len(got.Artifacts) != 1 {
+		t.Fatalf("artifacts length = %d, want 1", len(got.Artifacts))
+	}
+	if got.Artifacts[0].Name != "test-result" {
+		t.Errorf("artifact name = %s, want test-result", got.Artifacts[0].Name)
+	}
+}
+
+func TestListTasks(t *testing.T) {
+	store := setupTestStore(t)
+
+	// Create 3 tasks
+	t1, _ := store.CreateTask("ctx-a", nil)
+	t2, _ := store.CreateTask("ctx-a", nil)
+	_, _ = store.CreateTask("ctx-b", nil)
+
+	// List all
+	resp, err := store.ListTasks(ListTasksRequest{})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if resp.TotalSize != 3 {
+		t.Errorf("total = %d, want 3", resp.TotalSize)
+	}
+
+	// Filter by context
+	resp, _ = store.ListTasks(ListTasksRequest{ContextID: "ctx-a"})
+	if resp.TotalSize != 2 {
+		t.Errorf("total for ctx-a = %d, want 2", resp.TotalSize)
+	}
+
+	// Filter by state
+	_ = store.UpdateTaskState(t1.ID, TaskStateWorking, nil)
+	state := TaskStateWorking
+	resp, _ = store.ListTasks(ListTasksRequest{Status: &state})
+	if resp.TotalSize != 1 {
+		t.Errorf("total for working = %d, want 1", resp.TotalSize)
+	}
+
+	// Pagination
+	resp, _ = store.ListTasks(ListTasksRequest{PageSize: 2})
+	if len(resp.Tasks) != 2 {
+		t.Errorf("page size 2 returned %d tasks", len(resp.Tasks))
+	}
+	if resp.NextPageToken == "" {
+		t.Error("expected nextPageToken for page 1 of 3")
+	}
+
+	// Next page
+	resp2, _ := store.ListTasks(ListTasksRequest{PageSize: 2, PageToken: resp.NextPageToken})
+	if len(resp2.Tasks) != 1 {
+		t.Errorf("page 2 returned %d tasks, want 1", len(resp2.Tasks))
+	}
+	_ = t2 // suppress unused
+}
+
+func TestPushNotificationConfig(t *testing.T) {
+	store := setupTestStore(t)
+
+	task, _ := store.CreateTask("", nil)
+
+	cfg := PushNotificationConfig{
+		URL: "https://example.com/webhook",
+		Authentication: &AuthenticationInfo{
+			Schemes: []string{"Bearer"},
+			Token:   "test-token",
+		},
+	}
+
+	created, err := store.CreatePushConfig(task.ID, cfg)
+	if err != nil {
+		t.Fatalf("CreatePushConfig: %v", err)
+	}
+	if created.ID == "" {
+		t.Error("push config ID should not be empty")
+	}
+	if created.URL != "https://example.com/webhook" {
+		t.Errorf("URL = %s", created.URL)
+	}
+
+	// Get
+	got, err := store.GetPushConfig(created.ID)
+	if err != nil {
+		t.Fatalf("GetPushConfig: %v", err)
+	}
+	if got.Authentication.Token != "test-token" {
+		t.Errorf("token = %s", got.Authentication.Token)
+	}
+
+	// List
+	configs, err := store.ListPushConfigs(task.ID)
+	if err != nil {
+		t.Fatalf("ListPushConfigs: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("configs length = %d, want 1", len(configs))
+	}
+
+	// Delete
+	err = store.DeletePushConfig(created.ID)
+	if err != nil {
+		t.Fatalf("DeletePushConfig: %v", err)
+	}
+	configs, _ = store.ListPushConfigs(task.ID)
+	if len(configs) != 0 {
+		t.Errorf("configs after delete = %d", len(configs))
+	}
+}
+
+func TestCleanupOldTasks(t *testing.T) {
+	store := setupTestStore(t)
+
+	task, _ := store.CreateTask("", nil)
+	_ = store.UpdateTaskState(task.ID, TaskStateWorking, nil)
+	_ = store.UpdateTaskState(task.ID, TaskStateCompleted, nil)
+
+	// Cleanup with zero retention (should delete everything completed)
+	deleted, err := store.CleanupOldTasks(0 * time.Second)
+	if err != nil {
+		t.Fatalf("CleanupOldTasks: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+
+	got, _ := store.GetTask(task.ID, nil)
+	if got != nil {
+		t.Error("task should have been cleaned up")
+	}
+}
+
+func TestGetTaskNotFound(t *testing.T) {
+	store := setupTestStore(t)
+
+	got, err := store.GetTask("nonexistent", nil)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil for nonexistent task")
+	}
+}

--- a/internal/a2a/types.go
+++ b/internal/a2a/types.go
@@ -1,0 +1,331 @@
+package a2a
+
+import "encoding/json"
+
+// A2A Protocol v0.3 types
+// https://github.com/a2aproject/A2A
+
+// --- Enums ---
+
+// TaskState represents the A2A task lifecycle states (SCREAMING_SNAKE_CASE per proto spec).
+type TaskState string
+
+const (
+	TaskStateSubmitted     TaskState = "TASK_STATE_SUBMITTED"
+	TaskStateWorking       TaskState = "TASK_STATE_WORKING"
+	TaskStateInputRequired TaskState = "TASK_STATE_INPUT_REQUIRED"
+	TaskStateAuthRequired  TaskState = "TASK_STATE_AUTH_REQUIRED"
+	TaskStateCompleted     TaskState = "TASK_STATE_COMPLETED"
+	TaskStateFailed        TaskState = "TASK_STATE_FAILED"
+	TaskStateCanceled      TaskState = "TASK_STATE_CANCELED"
+	TaskStateRejected      TaskState = "TASK_STATE_REJECTED"
+)
+
+// Role identifies the sender of a message.
+type Role string
+
+const (
+	RoleUser  Role = "ROLE_USER"
+	RoleAgent Role = "ROLE_AGENT"
+)
+
+// ProtocolBinding identifies the wire protocol.
+type ProtocolBinding string
+
+const (
+	BindingJSONRPC  ProtocolBinding = "JSONRPC"
+	BindingGRPC     ProtocolBinding = "GRPC"
+	BindingHTTPJSON ProtocolBinding = "HTTP+JSON"
+)
+
+// --- Core Data Model (Layer 1) ---
+
+// Task is the core stateful object in A2A.
+type Task struct {
+	ID        string                 `json:"id"`
+	ContextID string                 `json:"contextId,omitempty"`
+	Status    TaskStatus             `json:"status"`
+	History   []Message              `json:"history,omitempty"`
+	Artifacts []Artifact             `json:"artifacts,omitempty"`
+	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// TaskStatus represents the current state of a task.
+type TaskStatus struct {
+	State     TaskState `json:"state"`
+	Timestamp string    `json:"timestamp"`
+	Message   *Message  `json:"message,omitempty"`
+}
+
+// Message represents a communication between user and agent.
+type Message struct {
+	MessageID        string                 `json:"messageId,omitempty"`
+	Role             Role                   `json:"role"`
+	Parts            []Part                 `json:"parts"`
+	TaskID           string                 `json:"taskId,omitempty"`
+	ContextID        string                 `json:"contextId,omitempty"`
+	ReferenceTaskIDs []string               `json:"referenceTaskIds,omitempty"`
+	Extensions       []string               `json:"extensions,omitempty"`
+	Metadata         map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// Part represents a content element within a message or artifact.
+type Part struct {
+	Text      string                 `json:"text,omitempty"`
+	Data      string                 `json:"data,omitempty"` // base64 raw binary
+	Filename  string                 `json:"filename,omitempty"`
+	MediaType string                 `json:"mediaType,omitempty"`
+	URL       string                 `json:"url,omitempty"`
+	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// Artifact represents a named output produced by a task.
+type Artifact struct {
+	ArtifactID string                 `json:"artifactId"`
+	Name       string                 `json:"name"`
+	Parts      []Part                 `json:"parts"`
+	Extensions []string               `json:"extensions,omitempty"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// --- Agent Card ---
+
+// AgentCard describes an A2A agent's capabilities and endpoint.
+type AgentCard struct {
+	Name               string                       `json:"name"`
+	Description        string                       `json:"description,omitempty"`
+	Version            string                       `json:"version,omitempty"`
+	Provider           *Provider                    `json:"provider,omitempty"`
+	IconURL            string                       `json:"iconUrl,omitempty"`
+	DocumentationURL   string                       `json:"documentationUrl,omitempty"`
+	SupportedInterfaces []SupportedInterface         `json:"supportedInterfaces"`
+	Capabilities       *Capabilities                `json:"capabilities,omitempty"`
+	SecuritySchemes    map[string]SecurityScheme     `json:"securitySchemes,omitempty"`
+	Security           []map[string][]string         `json:"security,omitempty"`
+	DefaultInputModes  []string                     `json:"defaultInputModes,omitempty"`
+	DefaultOutputModes []string                     `json:"defaultOutputModes,omitempty"`
+	Skills             []Skill                      `json:"skills"`
+	Signatures         []json.RawMessage            `json:"signatures,omitempty"`
+}
+
+// Provider describes the organization behind an agent.
+type Provider struct {
+	Organization string `json:"organization"`
+	URL          string `json:"url,omitempty"`
+}
+
+// SupportedInterface describes a protocol endpoint.
+type SupportedInterface struct {
+	URL             string          `json:"url"`
+	ProtocolBinding ProtocolBinding `json:"protocolBinding"`
+	ProtocolVersion string          `json:"protocolVersion"`
+}
+
+// Capabilities declares optional features the agent supports.
+type Capabilities struct {
+	Streaming              bool                 `json:"streaming,omitempty"`
+	PushNotifications      bool                 `json:"pushNotifications,omitempty"`
+	ExtendedAgentCard      bool                 `json:"extendedAgentCard,omitempty"`
+	StateTransitionHistory bool                 `json:"stateTransitionHistory,omitempty"`
+	Extensions             []ExtensionDecl      `json:"extensions,omitempty"`
+}
+
+// ExtensionDecl declares an extension the agent supports.
+type ExtensionDecl struct {
+	URI         string `json:"uri"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+// SecurityScheme describes an authentication mechanism.
+type SecurityScheme struct {
+	Type             string                 `json:"type"` // apiKey, http, oauth2, openIdConnect, mutualTLS
+	Description      string                 `json:"description,omitempty"`
+	Name             string                 `json:"name,omitempty"`             // apiKey: header/query/cookie name
+	In               string                 `json:"in,omitempty"`              // apiKey: header, query, cookie
+	Scheme           string                 `json:"scheme,omitempty"`          // http: bearer, basic
+	BearerFormat     string                 `json:"bearerFormat,omitempty"`    // http: JWT, etc.
+	Flows            *OAuthFlows            `json:"flows,omitempty"`           // oauth2
+	OpenIDConnectURL string                 `json:"openIdConnectUrl,omitempty"`
+}
+
+// OAuthFlows describes OAuth 2.0 flows.
+type OAuthFlows struct {
+	AuthorizationCode *OAuthFlow `json:"authorizationCode,omitempty"`
+	ClientCredentials *OAuthFlow `json:"clientCredentials,omitempty"`
+	DeviceCode        *OAuthFlow `json:"deviceCode,omitempty"`
+}
+
+// OAuthFlow describes a single OAuth 2.0 flow.
+type OAuthFlow struct {
+	AuthorizationURL string            `json:"authorizationUrl,omitempty"`
+	TokenURL         string            `json:"tokenUrl,omitempty"`
+	DeviceAuthURL    string            `json:"deviceAuthorizationUrl,omitempty"`
+	Scopes           map[string]string `json:"scopes,omitempty"`
+}
+
+// Skill describes a capability the agent advertises.
+type Skill struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Examples    []string `json:"examples,omitempty"`
+	InputModes  []string `json:"inputModes,omitempty"`
+	OutputModes []string `json:"outputModes,omitempty"`
+}
+
+// --- Request/Response Types ---
+
+// SendMessageRequest is the request body for message/send.
+type SendMessageRequest struct {
+	Message       Message                    `json:"message"`
+	Configuration *SendMessageConfiguration  `json:"configuration,omitempty"`
+	Metadata      map[string]interface{}     `json:"metadata,omitempty"`
+}
+
+// SendMessageConfiguration controls send behavior.
+type SendMessageConfiguration struct {
+	ReturnImmediately    bool                     `json:"returnImmediately,omitempty"`
+	PushNotificationConfig *PushNotificationConfig `json:"pushNotificationConfig,omitempty"`
+}
+
+// SendMessageResponse can be either a Task or a Message.
+type SendMessageResponse struct {
+	Task    *Task    `json:"task,omitempty"`
+	Message *Message `json:"message,omitempty"`
+}
+
+// GetTaskRequest is the request for tasks/get.
+type GetTaskRequest struct {
+	TaskID        string `json:"taskId"`
+	HistoryLength *int   `json:"historyLength,omitempty"`
+}
+
+// ListTasksRequest is the request for tasks/list.
+type ListTasksRequest struct {
+	ContextID        string     `json:"contextId,omitempty"`
+	Status           *TaskState `json:"status,omitempty"`
+	PageSize         int        `json:"pageSize,omitempty"`
+	PageToken        string     `json:"pageToken,omitempty"`
+	IncludeArtifacts bool       `json:"includeArtifacts,omitempty"`
+	HistoryLength    *int       `json:"historyLength,omitempty"`
+}
+
+// ListTasksResponse is the response for tasks/list.
+type ListTasksResponse struct {
+	Tasks         []Task `json:"tasks"`
+	TotalSize     int    `json:"totalSize,omitempty"`
+	PageSize      int    `json:"pageSize,omitempty"`
+	NextPageToken string `json:"nextPageToken,omitempty"`
+}
+
+// CancelTaskRequest is the request for tasks/cancel.
+type CancelTaskRequest struct {
+	TaskID string `json:"taskId"`
+}
+
+// SubscribeToTaskRequest is the request for tasks/subscribe.
+type SubscribeToTaskRequest struct {
+	TaskID        string `json:"taskId"`
+	HistoryLength *int   `json:"historyLength,omitempty"`
+}
+
+// --- Push Notifications ---
+
+// PushNotificationConfig defines a webhook endpoint for task updates.
+type PushNotificationConfig struct {
+	ID             string              `json:"id,omitempty"`
+	URL            string              `json:"url"`
+	TaskID         string              `json:"taskId,omitempty"`
+	Authentication *AuthenticationInfo `json:"authentication,omitempty"`
+}
+
+// AuthenticationInfo provides credentials for push notification delivery.
+type AuthenticationInfo struct {
+	Schemes []string `json:"schemes,omitempty"`
+	Token   string   `json:"token,omitempty"`
+}
+
+// CreatePushNotificationConfigRequest is the request to create a push config.
+type CreatePushNotificationConfigRequest struct {
+	TaskID         string              `json:"taskId"`
+	URL            string              `json:"url"`
+	Authentication *AuthenticationInfo `json:"authentication,omitempty"`
+}
+
+// --- Streaming ---
+
+// StreamResponse is an SSE event payload containing exactly one field.
+type StreamResponse struct {
+	Task           *Task                    `json:"task,omitempty"`
+	Message        *Message                 `json:"message,omitempty"`
+	StatusUpdate   *TaskStatusUpdateEvent   `json:"statusUpdate,omitempty"`
+	ArtifactUpdate *TaskArtifactUpdateEvent `json:"artifactUpdate,omitempty"`
+}
+
+// TaskStatusUpdateEvent is a streaming status change notification.
+type TaskStatusUpdateEvent struct {
+	TaskID    string     `json:"taskId"`
+	ContextID string     `json:"contextId,omitempty"`
+	Status    TaskStatus `json:"status"`
+}
+
+// TaskArtifactUpdateEvent is a streaming artifact notification.
+type TaskArtifactUpdateEvent struct {
+	TaskID    string   `json:"taskId"`
+	ContextID string   `json:"contextId,omitempty"`
+	Artifact  Artifact `json:"artifact"`
+}
+
+// --- JSON-RPC ---
+
+// JSONRPCRequest represents a JSON-RPC 2.0 request.
+type JSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// JSONRPCResponse represents a JSON-RPC 2.0 response.
+type JSONRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *JSONRPCError   `json:"error,omitempty"`
+}
+
+// JSONRPCError represents a JSON-RPC 2.0 error object.
+type JSONRPCError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// --- Extended Agent Card ---
+
+// GetExtendedAgentCardRequest is the request for the extended card.
+type GetExtendedAgentCardRequest struct{}
+
+// ExtendedSkill extends Skill with full input/output schema.
+type ExtendedSkill struct {
+	Skill
+	InputSchema map[string]interface{} `json:"inputSchema,omitempty"`
+}
+
+// --- Constants ---
+
+const (
+	// ProtocolVersion is the A2A protocol version this implementation supports.
+	ProtocolVersion = "0.3"
+
+	// WellKnownPath is the discovery endpoint for the agent card.
+	WellKnownPath = "/.well-known/agent-card.json"
+
+	// DefaultPageSize is the default number of tasks returned per page.
+	DefaultPageSize = 20
+
+	// MaxPageSize is the maximum number of tasks returned per page.
+	MaxPageSize = 100
+)

--- a/internal/a2a/types.go
+++ b/internal/a2a/types.go
@@ -92,20 +92,20 @@ type Artifact struct {
 
 // AgentCard describes an A2A agent's capabilities and endpoint.
 type AgentCard struct {
-	Name               string                       `json:"name"`
-	Description        string                       `json:"description,omitempty"`
-	Version            string                       `json:"version,omitempty"`
-	Provider           *Provider                    `json:"provider,omitempty"`
-	IconURL            string                       `json:"iconUrl,omitempty"`
-	DocumentationURL   string                       `json:"documentationUrl,omitempty"`
-	SupportedInterfaces []SupportedInterface         `json:"supportedInterfaces"`
-	Capabilities       *Capabilities                `json:"capabilities,omitempty"`
-	SecuritySchemes    map[string]SecurityScheme     `json:"securitySchemes,omitempty"`
-	Security           []map[string][]string         `json:"security,omitempty"`
-	DefaultInputModes  []string                     `json:"defaultInputModes,omitempty"`
-	DefaultOutputModes []string                     `json:"defaultOutputModes,omitempty"`
-	Skills             []Skill                      `json:"skills"`
-	Signatures         []json.RawMessage            `json:"signatures,omitempty"`
+	Name                string                    `json:"name"`
+	Description         string                    `json:"description,omitempty"`
+	Version             string                    `json:"version,omitempty"`
+	Provider            *Provider                 `json:"provider,omitempty"`
+	IconURL             string                    `json:"iconUrl,omitempty"`
+	DocumentationURL    string                    `json:"documentationUrl,omitempty"`
+	SupportedInterfaces []SupportedInterface      `json:"supportedInterfaces"`
+	Capabilities        *Capabilities             `json:"capabilities,omitempty"`
+	SecuritySchemes     map[string]SecurityScheme `json:"securitySchemes,omitempty"`
+	Security            []map[string][]string     `json:"security,omitempty"`
+	DefaultInputModes   []string                  `json:"defaultInputModes,omitempty"`
+	DefaultOutputModes  []string                  `json:"defaultOutputModes,omitempty"`
+	Skills              []Skill                   `json:"skills"`
+	Signatures          []json.RawMessage         `json:"signatures,omitempty"`
 }
 
 // Provider describes the organization behind an agent.
@@ -123,11 +123,11 @@ type SupportedInterface struct {
 
 // Capabilities declares optional features the agent supports.
 type Capabilities struct {
-	Streaming              bool                 `json:"streaming,omitempty"`
-	PushNotifications      bool                 `json:"pushNotifications,omitempty"`
-	ExtendedAgentCard      bool                 `json:"extendedAgentCard,omitempty"`
-	StateTransitionHistory bool                 `json:"stateTransitionHistory,omitempty"`
-	Extensions             []ExtensionDecl      `json:"extensions,omitempty"`
+	Streaming              bool            `json:"streaming,omitempty"`
+	PushNotifications      bool            `json:"pushNotifications,omitempty"`
+	ExtendedAgentCard      bool            `json:"extendedAgentCard,omitempty"`
+	StateTransitionHistory bool            `json:"stateTransitionHistory,omitempty"`
+	Extensions             []ExtensionDecl `json:"extensions,omitempty"`
 }
 
 // ExtensionDecl declares an extension the agent supports.
@@ -139,14 +139,14 @@ type ExtensionDecl struct {
 
 // SecurityScheme describes an authentication mechanism.
 type SecurityScheme struct {
-	Type             string                 `json:"type"` // apiKey, http, oauth2, openIdConnect, mutualTLS
-	Description      string                 `json:"description,omitempty"`
-	Name             string                 `json:"name,omitempty"`             // apiKey: header/query/cookie name
-	In               string                 `json:"in,omitempty"`              // apiKey: header, query, cookie
-	Scheme           string                 `json:"scheme,omitempty"`          // http: bearer, basic
-	BearerFormat     string                 `json:"bearerFormat,omitempty"`    // http: JWT, etc.
-	Flows            *OAuthFlows            `json:"flows,omitempty"`           // oauth2
-	OpenIDConnectURL string                 `json:"openIdConnectUrl,omitempty"`
+	Type             string      `json:"type"` // apiKey, http, oauth2, openIdConnect, mutualTLS
+	Description      string      `json:"description,omitempty"`
+	Name             string      `json:"name,omitempty"`         // apiKey: header/query/cookie name
+	In               string      `json:"in,omitempty"`           // apiKey: header, query, cookie
+	Scheme           string      `json:"scheme,omitempty"`       // http: bearer, basic
+	BearerFormat     string      `json:"bearerFormat,omitempty"` // http: JWT, etc.
+	Flows            *OAuthFlows `json:"flows,omitempty"`        // oauth2
+	OpenIDConnectURL string      `json:"openIdConnectUrl,omitempty"`
 }
 
 // OAuthFlows describes OAuth 2.0 flows.
@@ -179,14 +179,14 @@ type Skill struct {
 
 // SendMessageRequest is the request body for message/send.
 type SendMessageRequest struct {
-	Message       Message                    `json:"message"`
-	Configuration *SendMessageConfiguration  `json:"configuration,omitempty"`
-	Metadata      map[string]interface{}     `json:"metadata,omitempty"`
+	Message       Message                   `json:"message"`
+	Configuration *SendMessageConfiguration `json:"configuration,omitempty"`
+	Metadata      map[string]interface{}    `json:"metadata,omitempty"`
 }
 
 // SendMessageConfiguration controls send behavior.
 type SendMessageConfiguration struct {
-	ReturnImmediately    bool                     `json:"returnImmediately,omitempty"`
+	ReturnImmediately      bool                    `json:"returnImmediately,omitempty"`
 	PushNotificationConfig *PushNotificationConfig `json:"pushNotificationConfig,omitempty"`
 }
 
@@ -290,10 +290,10 @@ type JSONRPCRequest struct {
 
 // JSONRPCResponse represents a JSON-RPC 2.0 response.
 type JSONRPCResponse struct {
-	JSONRPC string          `json:"jsonrpc"`
-	ID      interface{}     `json:"id,omitempty"`
-	Result  interface{}     `json:"result,omitempty"`
-	Error   *JSONRPCError   `json:"error,omitempty"`
+	JSONRPC string        `json:"jsonrpc"`
+	ID      interface{}   `json:"id,omitempty"`
+	Result  interface{}   `json:"result,omitempty"`
+	Error   *JSONRPCError `json:"error,omitempty"`
 }
 
 // JSONRPCError represents a JSON-RPC 2.0 error object.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/SimplyLiz/CodeMCP/internal/config"
+	"github.com/SimplyLiz/CodeMCP/internal/envelope"
 	"github.com/SimplyLiz/CodeMCP/internal/errors"
 	"github.com/SimplyLiz/CodeMCP/internal/query"
 	"github.com/SimplyLiz/CodeMCP/internal/repos"
@@ -455,6 +456,16 @@ func (s *MCPServer) MarkExpanded() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.expanded = true
+}
+
+// CallTool invokes an MCP tool handler by name and returns its envelope response.
+// This is the public bridge used by the A2A server to execute CKB tools.
+func (s *MCPServer) CallTool(name string, params map[string]interface{}) (*envelope.Response, error) {
+	handler, exists := s.tools[name]
+	if !exists {
+		return nil, fmt.Errorf("tool not found: %s", name)
+	}
+	return handler(params)
 }
 
 // GetRoots returns the current MCP roots from the client (v8.0)


### PR DESCRIPTION
## Summary
- Implement the full A2A (Agent-to-Agent) protocol v0.3 specification in a new `internal/a2a/` package (17 files, ~3.7K lines)
- All 80+ MCP tools automatically exposed as A2A skills via `MCPServer.CallTool()` bridge — zero handler duplication
- New CLI command `ckb a2a --port 8081` with agent card discovery, dual protocol bindings, SSE streaming, push notifications, and SQLite-backed task persistence

## Test plan
- [x] `go build ./...` — compiles clean
- [x] `go vet ./internal/a2a/...` — no warnings
- [x] `go test ./internal/a2a/...` — 16/16 tests pass (state machine, task store CRUD, converter)
- [x] `go test ./internal/mcp/...` — existing MCP tests still pass
- [ ] Manual: `./ckb a2a --port 8081` then `curl localhost:8081/.well-known/agent-card.json`
- [ ] Manual: `curl -X POST localhost:8081/message:send` with skill request payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)