### PR TITLE
feat: add index health hints to A2A endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ golangci-lint run
 # Start MCP server (for AI tool integration)
 ./ckb mcp
 
+# Start A2A protocol server (for agent-to-agent communication)
+./ckb a2a --port 8081
+
 # Run PR review (20 quality checks)
 ./ckb review
 ./ckb review --base=develop --format=markdown
@@ -131,14 +134,33 @@ claude mcp add ckb -- npx @tastehub/ckb mcp
 
 **PR Review (v8.2):** `reviewPR` — unified review with 20 quality checks (breaking, secrets, tests, complexity, health, coupling, hotspots, risk, critical-path, traceability, independence, generated, classify, split, dead-code, test-gaps, blast-radius, comment-drift, format-consistency, bug-patterns); optional `--llm` flag for Claude-powered narrative
 
+## A2A Integration
+
+CKB also supports the A2A (Agent-to-Agent) protocol v0.3, enabling agent-to-agent communication over HTTP. All 80+ MCP tools are exposed as A2A skills.
+
+```bash
+# Start the A2A server
+ckb a2a --port 8081
+
+# Agent card (discovery)
+curl http://localhost:8081/.well-known/agent-card.json
+
+# Health with index freshness
+curl http://localhost:8081/health
+
+# Invoke a skill
+curl -X POST http://localhost:8081/message:send \
+  -d '{"message":{"role":"ROLE_USER","parts":[{"text":"{\"skill\":\"getStatus\",\"params\":{}}"}]}}'
+```
+
 ## Architecture Overview
 
-CKB is a code intelligence orchestration layer with three interfaces (CLI, HTTP API, MCP) that all flow through a central query engine.
+CKB is a code intelligence orchestration layer with four interfaces (CLI, HTTP API, MCP, A2A) that all flow through a central query engine.
 
 ### Layer Structure
 
 ```
-Interfaces (cmd/ckb/, internal/api/, internal/mcp/)
+Interfaces (cmd/ckb/, internal/api/, internal/mcp/, internal/a2a/)
     ↓
 Query Engine (internal/query/)
     ↓
@@ -157,6 +179,7 @@ Storage Layer (internal/storage/) - SQLite for caching and symbol mappings
 - **internal/compression/**: Response budget enforcement for LLM-optimized output.
 - **internal/impact/**: Change impact analysis with visibility detection and risk scoring.
 - **internal/mcp/**: Model Context Protocol server (80+ tools).
+- **internal/a2a/**: Agent-to-Agent protocol server (v0.3). Wraps MCP tools as A2A skills with task persistence, SSE streaming, push notifications.
 - **internal/ownership/**: CODEOWNERS parsing + git-blame analysis with time decay.
 - **internal/responsibilities/**: Module responsibility extraction from READMEs and code.
 - **internal/hotspots/**: Churn tracking with trend analysis and projections.

--- a/docs/features/a2a/overview.md
+++ b/docs/features/a2a/overview.md
@@ -1,0 +1,66 @@
+# CKB A2A Protocol Support
+
+CKB implements the [A2A (Agent-to-Agent) protocol v0.3](https://github.com/a2aproject/A2A), exposing all MCP tools as A2A skills over HTTP.
+
+## Architecture
+
+```
+A2A Client (any A2A agent)
+    │
+    ├── GET  /.well-known/agent-card.json  → Agent discovery
+    ├── POST /message:send                  → Skill invocation (HTTP+JSON)
+    ├── POST /                              → Skill invocation (JSON-RPC 2.0)
+    ├── POST /message:stream                → SSE streaming
+    ├── GET  /tasks/{id}                    → Task status
+    ├── GET  /health                        → Repo/index health + suggestions
+    │
+    ▼
+internal/a2a/Server
+    │
+    ├── SkillRegistry  ← maps MCP tools → A2A skills (zero duplication)
+    ├── TaskStore       ← SQLite (.ckb/a2a_tasks.db) task persistence
+    ├── PushManager     ← webhook delivery with retries
+    │
+    └── MCPServer.CallTool()  ← executes the actual tool handler
+            │
+            ▼
+        query.Engine → backends (SCIP, LSP, Git)
+```
+
+## Key Design Decisions
+
+1. **Zero handler duplication** — A2A wraps MCP tools via `MCPServer.CallTool()`, not by reimplementing them.
+2. **Dual protocol binding** — JSON-RPC and HTTP+JSON on the same port, sharing `do*` handler methods.
+3. **Separate task store** — `.ckb/a2a_tasks.db` (SQLite), independent from the jobs DB.
+4. **Atomic state transitions** — Conditional `UPDATE ... WHERE state IN (valid_sources)` prevents TOCTOU races.
+5. **Index health surfaced** — `/health` and task metadata include index freshness so agents know when to reindex.
+
+## Health & Index Hints
+
+The `/health` endpoint returns:
+- `index.initialized` — whether `ckb init` has been run
+- `index.fresh` — whether the SCIP index is up to date
+- `index.commitsBehind` — how stale the index is
+- `suggestions[]` — actionable hints ("run ckb index", "use reindex skill")
+
+Task responses include `metadata.indexWarnings` when results may be stale.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `internal/a2a/types.go` | A2A v0.3 protocol types |
+| `internal/a2a/server.go` | Server lifecycle, SSE fan-out |
+| `internal/a2a/routes.go` | Route registration, health endpoint |
+| `internal/a2a/handlers.go` | Shared do* handlers for both bindings |
+| `internal/a2a/jsonrpc.go` | JSON-RPC 2.0 dispatch |
+| `internal/a2a/streaming.go` | SSE streaming for send/subscribe |
+| `internal/a2a/task_store.go` | SQLite task persistence |
+| `internal/a2a/task_state.go` | State machine |
+| `internal/a2a/skill_registry.go` | MCP tools → A2A skills bridge |
+| `internal/a2a/agent_card.go` | Agent card generation |
+| `internal/a2a/push.go` | Webhook delivery |
+| `internal/a2a/middleware.go` | Auth, CORS, version, logging |
+| `internal/a2a/errors.go` | A2A error codes |
+| `internal/a2a/converter.go` | envelope.Response ↔ A2A types |
+| `cmd/ckb/a2a.go` | CLI command |

--- a/internal/a2a/handlers.go
+++ b/internal/a2a/handlers.go
@@ -115,6 +115,9 @@ func (s *Server) doSendMessage(req SendMessageRequest) (*Task, *A2AError) {
 		},
 	})
 
+	// Attach index freshness warnings to task metadata
+	s.attachIndexWarnings(task.ID)
+
 	// Return final task
 	finalTask, getErr := s.store.GetTask(task.ID, nil)
 	if getErr != nil {
@@ -439,4 +442,48 @@ func (s *Server) getTaskOrError(taskID string) (*Task, *A2AError) {
 		return nil, NewTaskNotFoundError(taskID)
 	}
 	return task, nil
+}
+
+// attachIndexWarnings checks index freshness and adds warnings to task metadata.
+// This surfaces reindex hints to consuming agents so they know results may be stale.
+func (s *Server) attachIndexWarnings(taskID string) {
+	indexStatus := s.getIndexStatus()
+
+	initialized, _ := indexStatus["initialized"].(bool)
+	fresh, _ := indexStatus["fresh"].(bool)
+
+	if initialized && fresh {
+		return
+	}
+
+	var warnings []string
+	if !initialized {
+		warnings = append(warnings, "CKB index not initialized — results are limited to git-based features. Run 'ckb init && ckb index' or use the 'reindex' skill.")
+	} else if !fresh {
+		if commitsBehind, ok := indexStatus["commitsBehind"].(int); ok && commitsBehind > 0 {
+			warnings = append(warnings, fmt.Sprintf("CKB index is %d commit(s) behind — results may be stale. Use the 'reindex' skill to refresh.", commitsBehind))
+		} else {
+			warnings = append(warnings, "CKB index may be stale. Use the 'reindex' skill to refresh.")
+		}
+	}
+
+	if len(warnings) == 0 {
+		return
+	}
+
+	// Store warnings as task metadata
+	task, err := s.store.GetTask(taskID, nil)
+	if err != nil || task == nil {
+		return
+	}
+
+	meta := task.Metadata
+	if meta == nil {
+		meta = make(map[string]any)
+	}
+	meta["indexWarnings"] = warnings
+	meta["indexStatus"] = indexStatus
+
+	// Update metadata in the store
+	s.store.UpdateTaskMetadata(taskID, meta)
 }

--- a/internal/a2a/handlers.go
+++ b/internal/a2a/handlers.go
@@ -484,6 +484,6 @@ func (s *Server) attachIndexWarnings(taskID string) {
 	meta["indexWarnings"] = warnings
 	meta["indexStatus"] = indexStatus
 
-	// Update metadata in the store
-	s.store.UpdateTaskMetadata(taskID, meta)
+	// Update metadata in the store (best-effort, non-critical)
+	_ = s.store.UpdateTaskMetadata(taskID, meta)
 }

--- a/internal/a2a/routes.go
+++ b/internal/a2a/routes.go
@@ -1,6 +1,13 @@
 package a2a
 
-import "net/http"
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"github.com/SimplyLiz/CodeMCP/internal/index"
+)
 
 // registerRoutes registers all A2A protocol routes.
 func (s *Server) registerRoutes() {
@@ -29,11 +36,117 @@ func (s *Server) registerRoutes() {
 	s.router.HandleFunc("GET /health", s.handleHealth)
 }
 
-// handleHealth returns a simple health check response.
+// handleHealth returns health with repo init status, index freshness, and suggestions.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"status":   "healthy",
+	health := map[string]any{
 		"protocol": "a2a",
 		"version":  ProtocolVersion,
-	})
+	}
+
+	// Index freshness
+	indexStatus := s.getIndexStatus()
+	health["index"] = indexStatus
+
+	// Backend health from query engine
+	ctx := context.Background()
+	statusResp, err := s.engine.GetStatus(ctx)
+	if err != nil {
+		health["status"] = "degraded"
+		health["error"] = err.Error()
+		health["suggestions"] = []string{"Run 'ckb init' to initialize the repository, then 'ckb index' to create the index."}
+		writeJSON(w, http.StatusOK, health)
+		return
+	}
+
+	health["status"] = "healthy"
+	if !statusResp.Healthy {
+		health["status"] = "degraded"
+	}
+
+	// Backend summary
+	backends := make([]map[string]any, 0, len(statusResp.Backends))
+	for _, b := range statusResp.Backends {
+		tier := "available"
+		if !b.Available {
+			tier = "unavailable"
+		} else if !b.Healthy {
+			tier = "degraded"
+		}
+		backends = append(backends, map[string]any{
+			"id":         b.Id,
+			"healthTier": tier,
+			"available":  b.Available,
+		})
+	}
+	health["backends"] = backends
+
+	// Actionable suggestions
+	suggestions := s.buildSuggestions(indexStatus, statusResp)
+	if len(suggestions) > 0 {
+		health["suggestions"] = suggestions
+	}
+
+	writeJSON(w, http.StatusOK, health)
+}
+
+// getIndexStatus returns index freshness information.
+func (s *Server) getIndexStatus() map[string]any {
+	repoRoot := s.engine.GetRepoRoot()
+	if repoRoot == "" {
+		return map[string]any{
+			"initialized": false,
+			"exists":      false,
+			"fresh":       false,
+			"reason":      "no repository configured",
+		}
+	}
+
+	ckbDir := filepath.Join(repoRoot, ".ckb")
+	meta, err := index.LoadMeta(ckbDir)
+	if err != nil || meta == nil {
+		return map[string]any{
+			"initialized": false,
+			"exists":      false,
+			"fresh":       false,
+			"reason":      "no index found — run 'ckb init && ckb index'",
+		}
+	}
+
+	staleness := meta.GetStaleness(repoRoot)
+	return map[string]any{
+		"initialized":   true,
+		"exists":        true,
+		"fresh":         !staleness.IsStale,
+		"reason":        staleness.Reason,
+		"indexAge":      staleness.IndexAge,
+		"commitsBehind": staleness.CommitsBehind,
+	}
+}
+
+// buildSuggestions generates actionable hints based on repo/index state.
+func (s *Server) buildSuggestions(indexStatus map[string]any, statusResp interface{}) []string {
+	var suggestions []string
+
+	initialized, _ := indexStatus["initialized"].(bool)
+	fresh, _ := indexStatus["fresh"].(bool)
+	commitsBehind, _ := indexStatus["commitsBehind"].(int)
+
+	if !initialized {
+		suggestions = append(suggestions,
+			"Repository is not indexed. Run 'ckb init && ckb index' to enable full code intelligence.",
+			"Without an index, only git-based features will be available.",
+		)
+	} else if !fresh {
+		if commitsBehind > 0 {
+			suggestions = append(suggestions,
+				fmt.Sprintf("Index is %d commit(s) behind. Run 'ckb index' to refresh, or use the 'reindex' skill.", commitsBehind),
+			)
+		} else if reason, ok := indexStatus["reason"].(string); ok && reason != "" {
+			suggestions = append(suggestions,
+				fmt.Sprintf("Index may be stale: %s. Run 'ckb index' to refresh, or use the 'reindex' skill.", reason),
+			)
+		}
+	}
+
+	return suggestions
 }

--- a/internal/a2a/task_store.go
+++ b/internal/a2a/task_store.go
@@ -294,6 +294,19 @@ func (s *TaskStore) UpdateTaskState(taskID string, newState TaskState, statusMsg
 	return nil
 }
 
+// UpdateTaskMetadata updates the metadata JSON on a task.
+func (s *TaskStore) UpdateTaskMetadata(taskID string, metadata map[string]any) error {
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("marshal metadata: %w", err)
+	}
+	_, err = s.conn.Exec(
+		`UPDATE tasks SET metadata = ? WHERE id = ?`,
+		string(b), taskID,
+	)
+	return err
+}
+
 // AddMessage adds a message to a task's history.
 func (s *TaskStore) AddMessage(taskID string, msg Message) error {
 	now := time.Now().UTC().Format(time.RFC3339Nano)


### PR DESCRIPTION
## Summary
- Enrich A2A `/health` endpoint with repo init status, index freshness (`commitsBehind`, `fresh`), backend health tiers, and actionable `suggestions[]` so consuming agents know when to trigger a reindex
- Attach `indexWarnings` and `indexStatus` to task metadata when results may be stale
- Update CLAUDE.md with A2A command, architecture, and package references
- Add `docs/features/a2a/overview.md` internal architecture doc

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go test ./internal/a2a/...` — 16/16 pass
- [ ] Manual: `curl localhost:8081/health` shows `index.fresh`, `suggestions`
- [ ] Manual: invoke a skill when index is stale, verify `metadata.indexWarnings` in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)