### PR TITLE
fix: wire push notifications and expose state history

### DIFF
--- a/internal/a2a/server.go
+++ b/internal/a2a/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	config    ServerConfig
 	store     *TaskStore
 	skills    *SkillRegistry
+	push      *PushManager
 
 	// SSE subscriptions: taskID -> list of subscriber channels
 	subs   map[string][]chan StreamResponse
@@ -53,6 +54,7 @@ func NewServer(engine *query.Engine, mcpServer *mcp.MCPServer, logger *slog.Logg
 		config:    config,
 		store:     store,
 		skills:    NewSkillRegistry(mcpServer),
+		push:      NewPushManager(store, logger),
 		subs:      make(map[string][]chan StreamResponse),
 	}
 
@@ -127,18 +129,15 @@ func (s *Server) unsubscribe(taskID string, ch chan StreamResponse) {
 	}
 }
 
-// notify fans out an event to all subscribers of a task.
-// Copies the subscriber slice under the lock to avoid send-on-closed-channel
-// if a concurrent unsubscribe closes a channel during iteration.
+// notify fans out an event to all SSE subscribers and push notification webhooks.
 func (s *Server) notify(taskID string, event StreamResponse) {
+	// Fan out to in-memory SSE subscribers
 	s.subsMu.RLock()
 	subs := make([]chan StreamResponse, len(s.subs[taskID]))
 	copy(subs, s.subs[taskID])
 	s.subsMu.RUnlock()
 
 	for _, ch := range subs {
-		// Recover from send-on-closed-channel if Shutdown closes a channel
-		// between our copy and the send.
 		func() {
 			defer func() { _ = recover() }()
 			select {
@@ -146,6 +145,11 @@ func (s *Server) notify(taskID string, event StreamResponse) {
 			default:
 			}
 		}()
+	}
+
+	// Deliver to push notification webhooks (async, non-blocking)
+	if s.push != nil {
+		s.push.Notify(taskID, event)
 	}
 }
 

--- a/internal/a2a/task_store.go
+++ b/internal/a2a/task_store.go
@@ -229,6 +229,15 @@ func (s *TaskStore) GetTask(taskID string, historyLength *int) (*Task, error) {
 	}
 	task.Artifacts = artifacts
 
+	// Load state transition history
+	statusHistory, err := s.getStatusHistory(taskID)
+	if err != nil {
+		return nil, err
+	}
+	if len(statusHistory) > 0 {
+		task.StatusHistory = statusHistory
+	}
+
 	return task, nil
 }
 
@@ -657,6 +666,41 @@ func (s *TaskStore) getArtifacts(taskID string) ([]Artifact, error) {
 	}
 
 	return artifacts, nil
+}
+
+func (s *TaskStore) getStatusHistory(taskID string) ([]TaskStatus, error) {
+	rows, err := s.conn.Query(
+		`SELECT state, message, timestamp FROM task_status_history WHERE task_id = ? ORDER BY id ASC`,
+		taskID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query status history: %w", err)
+	}
+	defer rows.Close()
+
+	var history []TaskStatus
+	for rows.Next() {
+		var (
+			state     string
+			msgJSON   sql.NullString
+			timestamp string
+		)
+		if err = rows.Scan(&state, &msgJSON, &timestamp); err != nil {
+			continue
+		}
+		status := TaskStatus{
+			State:     TaskState(state),
+			Timestamp: timestamp,
+		}
+		if msgJSON.Valid {
+			var msg Message
+			if json.Unmarshal([]byte(msgJSON.String), &msg) == nil {
+				status.Message = &msg
+			}
+		}
+		history = append(history, status)
+	}
+	return history, nil
 }
 
 func joinAnd(clauses []string) string {

--- a/internal/a2a/types.go
+++ b/internal/a2a/types.go
@@ -42,12 +42,13 @@ const (
 
 // Task is the core stateful object in A2A.
 type Task struct {
-	ID        string                 `json:"id"`
-	ContextID string                 `json:"contextId,omitempty"`
-	Status    TaskStatus             `json:"status"`
-	History   []Message              `json:"history,omitempty"`
-	Artifacts []Artifact             `json:"artifacts,omitempty"`
-	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+	ID            string                 `json:"id"`
+	ContextID     string                 `json:"contextId,omitempty"`
+	Status        TaskStatus             `json:"status"`
+	History       []Message              `json:"history,omitempty"`
+	Artifacts     []Artifact             `json:"artifacts,omitempty"`
+	Metadata      map[string]interface{} `json:"metadata,omitempty"`
+	StatusHistory []TaskStatus           `json:"statusHistory,omitempty"`
 }
 
 // TaskStatus represents the current state of a task.


### PR DESCRIPTION
## Summary
- Wire `PushManager` into the A2A server so configured webhooks actually receive task events (previously only in-memory SSE subscribers were notified)
- Expose state transition history in task responses via `statusHistory` field (data was already recorded in `task_status_history` table but never surfaced)

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go test ./internal/a2a/...` — all pass
- [x] `go vet` + `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)