### PR TITLE
feat: add findUnwiredModules — entrypoint reachability check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,12 @@ golangci-lint run
 # Start A2A protocol server (for agent-to-agent communication)
 ./ckb a2a --port 8081
 
-# Run PR review (20 quality checks)
+# Find exported symbols not reachable from entrypoints
+./ckb unwired
+./ckb unwired --scope internal/cost,internal/multisampling
+./ckb unwired --format json
+
+# Run PR review (21 quality checks)
 ./ckb review
 ./ckb review --base=develop --format=markdown
 ./ckb review --checks=breaking,secrets,health --ci
@@ -124,7 +129,7 @@ claude mcp add ckb -- npx @tastehub/ckb mcp
 
 **Intelligence (v6.5):** `explainOrigin`, `analyzeCoupling`, `exportForLLM`, `auditRisk`
 
-**Code Analysis (v7.6):** `findDeadCode` (static dead code detection), `getAffectedTests`, `compareAPI`
+**Code Analysis (v7.6):** `findDeadCode` (static dead code detection), `findUnwiredModules` (entrypoint reachability — detects "built but never plugged in" modules), `getAffectedTests`, `compareAPI`
 
 **Compound Operations (v8.0):** `explore`, `understand`, `prepareChange`, `batchGet`, `batchSearch`
 
@@ -132,7 +137,7 @@ claude mcp add ckb -- npx @tastehub/ckb mcp
 
 **Index Management (v8.0):** `reindex` (trigger index refresh), enhanced `getStatus` with health tiers
 
-**PR Review (v8.2):** `reviewPR` — unified review with 20 quality checks (breaking, secrets, tests, complexity, health, coupling, hotspots, risk, critical-path, traceability, independence, generated, classify, split, dead-code, test-gaps, blast-radius, comment-drift, format-consistency, bug-patterns); optional `--llm` flag for Claude-powered narrative
+**PR Review (v8.2):** `reviewPR` — unified review with 21 quality checks (breaking, secrets, tests, complexity, health, coupling, hotspots, risk, critical-path, traceability, independence, generated, classify, split, dead-code, unwired, test-gaps, blast-radius, comment-drift, format-consistency, bug-patterns); optional `--llm` flag for Claude-powered narrative
 
 ## A2A Integration
 

--- a/cmd/ckb/unwired.go
+++ b/cmd/ckb/unwired.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/SimplyLiz/CodeMCP/internal/query"
+)
+
+var (
+	unwiredFormat        string
+	unwiredScope         []string
+	unwiredLimit         int
+	unwiredMinConfidence float64
+	unwiredExclude       []string
+	unwiredIncludeTypes  bool
+	unwiredMaxNodes      int
+)
+
+var unwiredCmd = &cobra.Command{
+	Use:   "unwired",
+	Short: "Find exported symbols not reachable from entrypoints",
+	Long: `Find exported functions and methods that are never transitively called
+from any application entrypoint (main, server, CLI commands).
+
+This detects the "built but never plugged in" pattern where modules exist
+and are tested but aren't wired into the execution pipeline.
+
+Complements dead-code (which checks reference counts) by checking
+reachability from the actual runtime entry points.
+
+Examples:
+  ckb unwired
+  ckb unwired --scope src/cost,src/multisampling
+  ckb unwired --min-confidence 0.9
+  ckb unwired --include-types
+  ckb unwired --format json`,
+	Run: runUnwired,
+}
+
+func init() {
+	unwiredCmd.Flags().StringVar(&unwiredFormat, "format", "human", "Output format (human, json)")
+	unwiredCmd.Flags().StringSliceVar(&unwiredScope, "scope", nil, "Limit to specific packages/paths")
+	unwiredCmd.Flags().IntVar(&unwiredLimit, "limit", 100, "Maximum results to return")
+	unwiredCmd.Flags().Float64Var(&unwiredMinConfidence, "min-confidence", 0.80, "Minimum confidence threshold (0-1)")
+	unwiredCmd.Flags().StringSliceVar(&unwiredExclude, "exclude", nil, "Patterns to exclude")
+	unwiredCmd.Flags().BoolVar(&unwiredIncludeTypes, "include-types", false, "Include type definitions (higher FP rate)")
+	unwiredCmd.Flags().IntVar(&unwiredMaxNodes, "max-nodes", 10000, "Max symbols in reachable set")
+	rootCmd.AddCommand(unwiredCmd)
+}
+
+func runUnwired(cmd *cobra.Command, args []string) {
+	start := time.Now()
+	logger := newLogger(unwiredFormat)
+
+	repoRoot := mustGetRepoRoot()
+	engine := mustGetEngine(repoRoot, logger)
+	ctx := newContext()
+
+	opts := query.FindUnwiredModulesOptions{
+		Scope:           unwiredScope,
+		ExcludePatterns: unwiredExclude,
+		MinConfidence:   unwiredMinConfidence,
+		IncludeTypes:    unwiredIncludeTypes,
+		MaxNodes:        unwiredMaxNodes,
+		Limit:           unwiredLimit,
+	}
+
+	response, err := engine.FindUnwiredModules(ctx, opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if unwiredFormat == "json" {
+		data, err := json.MarshalIndent(response, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(data))
+	} else {
+		printUnwiredHuman(response)
+	}
+
+	logger.Debug("Unwired analysis completed",
+		"unwiredCount", response.Summary.UnwiredCount,
+		"reachableCount", response.ReachableCount,
+		"duration", time.Since(start).Milliseconds(),
+	)
+}
+
+func printUnwiredHuman(resp *query.FindUnwiredModulesResponse) {
+	fmt.Println("Unwired Module Analysis")
+	fmt.Println("============================================================")
+	fmt.Println()
+
+	if len(resp.Entrypoints) > 0 {
+		fmt.Printf("Entrypoints: %d\n", len(resp.Entrypoints))
+		for _, ep := range resp.Entrypoints {
+			fmt.Printf("  - %s\n", ep)
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("Reachable symbols: %d\n", resp.ReachableCount)
+	fmt.Printf("Total exported:    %d\n", resp.Summary.TotalExported)
+	fmt.Printf("Unwired:           %d\n", resp.Summary.UnwiredCount)
+	if resp.Partial {
+		fmt.Println("  (partial — reachable set budget exhausted)")
+	}
+	fmt.Println()
+
+	if len(resp.UnwiredModules) == 0 {
+		fmt.Println("No unwired modules found.")
+		return
+	}
+
+	for _, mod := range resp.UnwiredModules {
+		fmt.Printf("── %s (%d/%d exported symbols unwired)\n",
+			mod.Path, mod.Summary.UnwiredCount, mod.Summary.TotalExported)
+		for _, item := range mod.Items {
+			fmt.Printf("   %s %s  (%.0f%% confidence)\n",
+				item.Kind, item.SymbolName, item.Confidence*100)
+			fmt.Printf("     %s\n", item.Reason)
+			if item.ReferenceCount > 0 {
+				fmt.Printf("     refs: %d (test: %d)\n", item.ReferenceCount, item.TestReferences)
+			}
+		}
+		fmt.Println()
+	}
+}

--- a/internal/api/handlers_unwired.go
+++ b/internal/api/handlers_unwired.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/SimplyLiz/CodeMCP/internal/query"
+)
+
+// handleUnwired handles GET /unwired — find exported symbols not reachable from entrypoints.
+func (s *Server) handleUnwired(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+	q := r.URL.Query()
+
+	opts := query.FindUnwiredModulesOptions{
+		MinConfidence: 0.80,
+		Limit:         100,
+		MaxNodes:      10000,
+	}
+
+	if scope := q.Get("scope"); scope != "" {
+		opts.Scope = []string{scope}
+	}
+	if minConf := q.Get("minConfidence"); minConf != "" {
+		if v, err := strconv.ParseFloat(minConf, 64); err == nil {
+			opts.MinConfidence = v
+		}
+	}
+	if limit := q.Get("limit"); limit != "" {
+		if v, err := strconv.Atoi(limit); err == nil {
+			opts.Limit = v
+		}
+	}
+	if q.Get("includeTypes") == "true" {
+		opts.IncludeTypes = true
+	}
+
+	result, err := s.engine.FindUnwiredModules(ctx, opts)
+	if err != nil {
+		InternalError(w, "Failed to find unwired modules", err)
+		return
+	}
+
+	WriteJSON(w, result, http.StatusOK)
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -55,6 +55,9 @@ func (s *Server) registerRoutes() {
 	// v8.2 Unified PR Review
 	s.router.HandleFunc("/review/pr", s.handleReviewPR) // GET/POST
 
+	// Unwired module detection
+	s.router.HandleFunc("/unwired", s.handleUnwired) // GET /unwired?scope=...&minConfidence=...&limit=...
+
 	// v6.2 Federation endpoints
 	s.router.HandleFunc("/federations", s.handleListFederations)   // GET
 	s.router.HandleFunc("/federations/", s.handleFederationRoutes) // /federations/:name/*

--- a/internal/mcp/presets.go
+++ b/internal/mcp/presets.go
@@ -88,17 +88,18 @@ var Presets = map[string][]string{
 		"getOwnership",
 		"getOwnershipDrift",
 		"recentlyRelevant",
-		"scanSecrets",       // Secret detection for PR reviews
-		"reviewPR",          // Unified PR review with quality gates
-		"getAffectedTests",  // Tests covering changed code
-		"analyzeTestGaps",   // Untested functions in changed files
-		"compareAPI",        // Breaking API changes
-		"findDeadCode",      // Dead code in changes
-		"auditRisk",         // Multi-factor risk scoring
-		"analyzeChange",     // Change analysis
-		"getFileComplexity", // File complexity for review
-		"listEntrypoints",   // Key entry points in changed code
-		"auditCompliance",   // Regulatory compliance audit
+		"scanSecrets",        // Secret detection for PR reviews
+		"reviewPR",           // Unified PR review with quality gates
+		"getAffectedTests",   // Tests covering changed code
+		"analyzeTestGaps",    // Untested functions in changed files
+		"compareAPI",         // Breaking API changes
+		"findDeadCode",       // Dead code in changes
+		"findUnwiredModules", // Exported symbols not reachable from entrypoints
+		"auditRisk",          // Multi-factor risk scoring
+		"analyzeChange",      // Change analysis
+		"getFileComplexity",  // File complexity for review
+		"listEntrypoints",    // Key entry points in changed code
+		"auditCompliance",    // Regulatory compliance audit
 	},
 
 	// Refactor: core + refactoring analysis tools
@@ -114,9 +115,10 @@ var Presets = map[string][]string{
 		"justifySymbol",
 		"analyzeCoupling",
 		"findDeadCodeCandidates",
-		"findDeadCode",     // v7.6: Static dead code detection (no telemetry needed)
-		"getAffectedTests", // v7.6: Find tests affected by changes
-		"compareAPI",       // v7.6: Breaking change detection
+		"findDeadCode",       // v7.6: Static dead code detection (no telemetry needed)
+		"findUnwiredModules", // Exported symbols not reachable from entrypoints
+		"getAffectedTests",   // v7.6: Find tests affected by changes
+		"compareAPI",         // v7.6: Breaking change detection
 		"auditRisk",
 		"explainOrigin",
 		"scanSecrets",         // v8.0: Secret detection for security audits

--- a/internal/mcp/presets_test.go
+++ b/internal/mcp/presets_test.go
@@ -42,9 +42,9 @@ func TestPresetFiltering(t *testing.T) {
 		t.Fatalf("failed to set full preset: %v", err)
 	}
 	fullTools := server.GetFilteredTools()
-	// v8.3: Full now includes auditCompliance, listSymbols, getSymbolGraph (96)
-	if len(fullTools) != 96 {
-		t.Errorf("expected 96 full tools (v8.3), got %d", len(fullTools))
+	// v8.4: Full now includes findUnwiredModules (97)
+	if len(fullTools) != 97 {
+		t.Errorf("expected 97 full tools, got %d", len(fullTools))
 	}
 
 	// Full preset should still have core tools first

--- a/internal/mcp/token_budget_test.go
+++ b/internal/mcp/token_budget_test.go
@@ -34,8 +34,8 @@ func TestToolsListTokenBudget(t *testing.T) {
 		maxTools int
 	}{
 		{PresetCore, maxCorePresetBytes, 20, 24},     // v8.3: 24 tools (+explainPath, responsibilities, exportForLLM)
-		{PresetReview, maxReviewPresetBytes, 30, 40}, // v8.3: 40 tools (+auditCompliance)
-		{PresetFull, maxFullPresetBytes, 80, 96},     // v8.3: 96 tools (+listSymbols, getSymbolGraph)
+		{PresetReview, maxReviewPresetBytes, 30, 41}, // v8.4: 41 tools (+findUnwiredModules)
+		{PresetFull, maxFullPresetBytes, 80, 97},     // v8.4: 97 tools (+findUnwiredModules)
 	}
 
 	for _, tt := range tests {

--- a/internal/mcp/tool_impls_unwired.go
+++ b/internal/mcp/tool_impls_unwired.go
@@ -1,0 +1,70 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/SimplyLiz/CodeMCP/internal/envelope"
+	"github.com/SimplyLiz/CodeMCP/internal/query"
+)
+
+// toolFindUnwiredModules finds exported symbols not reachable from entrypoints.
+func (s *MCPServer) toolFindUnwiredModules(params map[string]interface{}) (*envelope.Response, error) {
+	opts := query.FindUnwiredModulesOptions{}
+
+	// Scope
+	if scopeRaw, ok := params["scope"].([]interface{}); ok {
+		for _, v := range scopeRaw {
+			if str, ok := v.(string); ok {
+				opts.Scope = append(opts.Scope, str)
+			}
+		}
+	}
+
+	// Exclude patterns
+	if patternsRaw, ok := params["excludePatterns"].([]interface{}); ok {
+		for _, p := range patternsRaw {
+			if str, ok := p.(string); ok {
+				opts.ExcludePatterns = append(opts.ExcludePatterns, str)
+			}
+		}
+	}
+
+	// Min confidence
+	opts.MinConfidence = 0.80
+	if v, ok := params["minConfidence"].(float64); ok {
+		opts.MinConfidence = v
+	}
+
+	// Include types
+	if v, ok := params["includeTypes"].(bool); ok {
+		opts.IncludeTypes = v
+	}
+
+	// Max nodes (reachable set budget)
+	opts.MaxNodes = 10000
+	if v, ok := params["maxNodes"].(float64); ok {
+		opts.MaxNodes = int(v)
+	}
+
+	// Limit
+	opts.Limit = 100
+	if v, ok := params["limit"].(float64); ok {
+		opts.Limit = int(v)
+	}
+
+	ctx := context.Background()
+	result, err := s.engine().FindUnwiredModules(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := NewToolResponse().Data(result)
+	if result != nil && result.ReachableCount == 0 {
+		resp.Warning("No entrypoints detected. Ensure your project has main/server/CLI entry files.")
+	}
+	if result != nil && result.Partial {
+		resp.Warning("Reachable set budget exhausted — results may be incomplete. Increase maxNodes for a full scan.")
+	}
+
+	return resp.Build(), nil
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -63,8 +63,8 @@ func (s *MCPServer) GetToolDefinitions() []Tool {
 		{
 			Name: "expandToolset",
 			Description: "Switch to a larger toolset for a specific workflow. Call this when you need tools not in the current set. Presets (each includes all core tools plus):\n" +
-				"• review (39 tools): reviewPR, auditCompliance, scanSecrets, analyzeTestGaps, getAffectedTests, compareAPI, findDeadCode, auditRisk, getOwnership — use for PR reviews, test coverage analysis, compliance audits, security\n" +
-				"• refactor (32 tools): analyzeCoupling, findCycles, suggestRefactorings, findDeadCode, compareAPI, explainOrigin — use for refactoring, dependency analysis, dead code removal\n" +
+				"• review (40 tools): reviewPR, auditCompliance, scanSecrets, analyzeTestGaps, getAffectedTests, compareAPI, findDeadCode, findUnwiredModules, auditRisk, getOwnership — use for PR reviews, test coverage analysis, compliance audits, security\n" +
+				"• refactor (33 tools): analyzeCoupling, findCycles, suggestRefactorings, findDeadCode, findUnwiredModules, compareAPI, explainOrigin — use for refactoring, dependency analysis, dead code removal\n" +
 				"• federation (36 tools): federationSearch*, listContracts, analyzeContractImpact — use for multi-repo queries, cross-repo analysis\n" +
 				"• docs (27 tools): indexDocs, getDocsForSymbol, checkDocStaleness, getDecisions, recordDecision — use for documentation, ADRs\n" +
 				"• ops (33 tools): doctor, reindex, daemonStatus, listJobs, webhooks, telemetry — use for diagnostics, daemon management\n" +
@@ -1675,6 +1675,50 @@ func (s *MCPServer) GetToolDefinitions() []Tool {
 				},
 			},
 		},
+		// Unwired Module Detection
+		{
+			Name:        "findUnwiredModules",
+			Description: "Find exported symbols that are never transitively reachable from application entrypoints (main, server, CLI). Detects the 'built but never plugged in' pattern where modules exist and are tested but aren't wired into the execution pipeline. Complements findDeadCode which only checks reference counts.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"scope": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+						"description": "Limit analysis to specific packages/paths",
+					},
+					"minConfidence": map[string]interface{}{
+						"type":        "number",
+						"default":     0.80,
+						"description": "Minimum confidence threshold (0-1)",
+					},
+					"includeTypes": map[string]interface{}{
+						"type":        "boolean",
+						"default":     false,
+						"description": "Include type definitions (higher false positive rate)",
+					},
+					"excludePatterns": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+						"description": "Glob patterns to exclude",
+					},
+					"maxNodes": map[string]interface{}{
+						"type":        "integer",
+						"default":     10000,
+						"description": "Max symbols in reachable set (budget for BFS traversal)",
+					},
+					"limit": map[string]interface{}{
+						"type":        "integer",
+						"default":     100,
+						"description": "Maximum results to return",
+					},
+				},
+			},
+		},
 		// v7.6 Affected Tests Tool
 		{
 			Name:        "getAffectedTests",
@@ -2501,6 +2545,7 @@ func (s *MCPServer) RegisterTools() {
 	s.tools["findDeadCodeCandidates"] = s.toolFindDeadCodeCandidates
 	// v7.6 Static Dead Code Detection
 	s.tools["findDeadCode"] = s.toolFindDeadCode
+	s.tools["findUnwiredModules"] = s.toolFindUnwiredModules
 	// v7.6 Affected Tests
 	s.tools["getAffectedTests"] = s.toolGetAffectedTests
 	// v7.6 Breaking Change Detection

--- a/internal/query/review.go
+++ b/internal/query/review.go
@@ -468,6 +468,17 @@ func (e *Engine) ReviewPR(ctx context.Context, opts ReviewPROptions) (*ReviewPRR
 		}()
 	}
 
+	// Check: Unwired Modules (SCIP-only, parallel safe)
+	if checkEnabled("unwired") {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, ff := e.checkUnwiredModules(ctx, changedFiles, opts)
+			addCheck(c)
+			addFindings(ff)
+		}()
+	}
+
 	// Check: Blast Radius (SCIP-only, parallel safe)
 	if checkEnabled("blast-radius") {
 		wg.Add(1)

--- a/internal/query/review_unwired.go
+++ b/internal/query/review_unwired.go
@@ -1,0 +1,94 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+)
+
+// checkUnwiredModules finds exported symbols in changed files that are never
+// transitively reachable from application entrypoints.
+func (e *Engine) checkUnwiredModules(ctx context.Context, changedFiles []string, opts ReviewPROptions) (ReviewCheck, []ReviewFinding) {
+	start := time.Now()
+
+	// Build scope from changed file directories
+	dirSet := make(map[string]bool)
+	for _, f := range changedFiles {
+		dirSet[filepath.Dir(f)] = true
+	}
+	dirs := make([]string, 0, len(dirSet))
+	for d := range dirSet {
+		dirs = append(dirs, d)
+	}
+
+	resp, err := e.FindUnwiredModules(ctx, FindUnwiredModulesOptions{
+		Scope:         dirs,
+		MinConfidence: 0.85, // Higher bar for PR review to reduce noise
+		Limit:         30,
+	})
+	if err != nil {
+		return ReviewCheck{
+			Name:     "unwired",
+			Status:   "skip",
+			Severity: "info",
+			Summary:  fmt.Sprintf("Could not analyze: %v", err),
+			Duration: time.Since(start).Milliseconds(),
+		}, nil
+	}
+
+	// Filter to only items that are in changed files
+	changedFileSet := make(map[string]bool)
+	for _, f := range changedFiles {
+		changedFileSet[f] = true
+	}
+
+	var findings []ReviewFinding
+	for _, mod := range resp.UnwiredModules {
+		for _, item := range mod.Items {
+			if !changedFileSet[item.FilePath] {
+				continue
+			}
+
+			findings = append(findings, ReviewFinding{
+				Check:     "unwired",
+				Severity:  "info",
+				File:      item.FilePath,
+				StartLine: item.LineNumber,
+				Message: fmt.Sprintf(
+					"Unwired: %s (%s) — %s (refs: %d, confidence: %.0f%%)",
+					item.SymbolName, item.Kind, item.Reason, item.ReferenceCount, item.Confidence*100,
+				),
+				Suggestion: "Verify this symbol is called from the main execution pipeline, or remove if no longer needed.",
+				Category:   "unwired",
+				RuleID:     "ckb/unwired/not-reachable",
+				Tier:       2,
+				Confidence: item.Confidence,
+			})
+		}
+	}
+
+	status := "pass"
+	summary := "All exported symbols are reachable from entrypoints"
+	if len(findings) > 0 {
+		status = "warn"
+		summary = fmt.Sprintf("%d unwired symbol(s) in changed files", len(findings))
+	}
+	if resp.Partial {
+		summary += " (partial — reachable set budget exhausted)"
+	}
+
+	return ReviewCheck{
+		Name:     "unwired",
+		Status:   status,
+		Severity: "info",
+		Summary:  summary,
+		Details: map[string]any{
+			"entrypoints":    resp.Entrypoints,
+			"reachableCount": resp.ReachableCount,
+			"partial":        resp.Partial,
+			"totalUnwired":   resp.Summary.UnwiredCount,
+		},
+		Duration: time.Since(start).Milliseconds(),
+	}, findings
+}

--- a/internal/query/unwired.go
+++ b/internal/query/unwired.go
@@ -1,0 +1,135 @@
+package query
+
+import (
+	"context"
+	"time"
+
+	"github.com/SimplyLiz/CodeMCP/internal/architecture"
+	"github.com/SimplyLiz/CodeMCP/internal/modules"
+	"github.com/SimplyLiz/CodeMCP/internal/unwired"
+)
+
+// FindUnwiredModulesOptions configures the unwired module detection.
+type FindUnwiredModulesOptions struct {
+	Scope           []string `json:"scope,omitempty"`
+	ExcludePatterns []string `json:"excludePatterns,omitempty"`
+	MaxNodes        int      `json:"maxNodes"`
+	MinConfidence   float64  `json:"minConfidence"`
+	IncludeTypes    bool     `json:"includeTypes"`
+	Limit           int      `json:"limit"`
+}
+
+// FindUnwiredModulesResponse is the response from unwired module detection.
+type FindUnwiredModulesResponse struct {
+	UnwiredModules []unwired.UnwiredModule `json:"unwiredModules"`
+	Summary        unwired.Summary         `json:"summary"`
+	Entrypoints    []string                `json:"entrypoints"`
+	ReachableCount int                     `json:"reachableCount"`
+	Partial        bool                    `json:"partial,omitempty"`
+	Provenance     *Provenance             `json:"provenance,omitempty"`
+}
+
+// FindUnwiredModules detects exported symbols that are never transitively
+// reachable from application entrypoints. This catches the "built but never
+// plugged in" pattern where modules exist and are tested but aren't wired
+// into the main request/execution pipeline.
+func (e *Engine) FindUnwiredModules(ctx context.Context, opts FindUnwiredModulesOptions) (*FindUnwiredModulesResponse, error) {
+	startTime := time.Now()
+
+	// Apply defaults
+	if opts.MinConfidence == 0 {
+		opts.MinConfidence = 0.80
+	}
+	if opts.Limit == 0 {
+		opts.Limit = 100
+	}
+	if opts.MaxNodes == 0 {
+		opts.MaxNodes = 10000
+	}
+
+	// Check SCIP availability
+	if e.scipAdapter == nil || !e.scipAdapter.IsAvailable() {
+		return &FindUnwiredModulesResponse{
+			Summary: unwired.Summary{ByKind: make(map[string]int)},
+		}, nil
+	}
+
+	// Detect entrypoints via architecture module
+	importScanner := modules.NewImportScanner(&e.config.ImportScan, e.logger)
+	generator := architecture.NewArchitectureGenerator(e.repoRoot, e.config, importScanner, e.logger)
+
+	repoState, _ := e.GetRepoState(ctx, "head")
+	stateID := ""
+	if repoState != nil {
+		stateID = repoState.RepoStateId
+	}
+
+	arch, err := generator.Generate(ctx, stateID, &architecture.GeneratorOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	entrypoints := arch.Entrypoints
+
+	// Filter to non-test entrypoints
+	var appEntrypoints []architecture.Entrypoint
+	seen := make(map[string]bool)
+	for _, ep := range entrypoints {
+		if ep.Kind != architecture.EntrypointTest && !seen[ep.FileId] {
+			seen[ep.FileId] = true
+			appEntrypoints = append(appEntrypoints, ep)
+		}
+	}
+
+	// Also detect entrypoints from package.json scripts (e.g., "dev": "bun run src/server.ts")
+	detector := unwired.NewDetector(e.scipAdapter, e.repoRoot, e.logger)
+	scriptEPs := detector.DetectScriptEntrypoints()
+	for _, ep := range scriptEPs {
+		if !seen[ep.FileId] {
+			seen[ep.FileId] = true
+			appEntrypoints = append(appEntrypoints, ep)
+		}
+	}
+
+	var entrypointNames []string
+	for _, ep := range appEntrypoints {
+		entrypointNames = append(entrypointNames, ep.FileId)
+	}
+
+	if len(appEntrypoints) == 0 {
+		return &FindUnwiredModulesResponse{
+			Summary:     unwired.Summary{ByKind: make(map[string]int)},
+			Entrypoints: entrypointNames,
+		}, nil
+	}
+
+	// Build reachable set via BFS from entrypoints
+	reachable, partial := detector.BuildReachableSet(ctx, appEntrypoints)
+
+	// Analyze: find exported symbols not in the reachable set
+	detOpts := unwired.DetectorOptions{
+		Scope:           opts.Scope,
+		ExcludePatterns: opts.ExcludePatterns,
+		MaxNodes:        opts.MaxNodes,
+		MinConfidence:   opts.MinConfidence,
+		IncludeTypes:    opts.IncludeTypes,
+		Limit:           opts.Limit,
+	}
+
+	result, err := detector.Analyze(ctx, detOpts, reachable)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build provenance
+	prov := e.buildProvenance(repoState, "head", startTime, nil, CompletenessInfo{})
+
+	return &FindUnwiredModulesResponse{
+		UnwiredModules: result.UnwiredModules,
+		Summary:        result.Summary,
+		Entrypoints:    entrypointNames,
+		ReachableCount: result.ReachableCount,
+		Partial:        partial,
+		Provenance:     prov,
+	}, nil
+}

--- a/internal/unwired/detector.go
+++ b/internal/unwired/detector.go
@@ -1,0 +1,635 @@
+package unwired
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/SimplyLiz/CodeMCP/internal/architecture"
+	"github.com/SimplyLiz/CodeMCP/internal/backends/scip"
+	"github.com/SimplyLiz/CodeMCP/internal/deadcode"
+)
+
+const (
+	defaultMaxNodes = 10000
+	defaultLimit    = 100
+)
+
+// Detector finds exported symbols that are never reachable from entrypoints.
+type Detector struct {
+	scipAdapter *scip.SCIPAdapter
+	repoRoot    string
+	logger      *slog.Logger
+}
+
+// NewDetector creates a new unwired module detector.
+func NewDetector(scipAdapter *scip.SCIPAdapter, repoRoot string, logger *slog.Logger) *Detector {
+	return &Detector{
+		scipAdapter: scipAdapter,
+		repoRoot:    repoRoot,
+		logger:      logger,
+	}
+}
+
+// BuildReachableSet performs BFS from entrypoint symbols to build the set of all
+// transitively reachable symbol IDs.
+func (d *Detector) BuildReachableSet(ctx context.Context, entrypoints []architecture.Entrypoint) (map[string]bool, bool) {
+	index := d.scipAdapter.GetIndex()
+	if index == nil {
+		return nil, false
+	}
+
+	reachable := make(map[string]bool)
+	queue := make([]string, 0, 256)
+	maxNodes := defaultMaxNodes
+	partial := false
+
+	// Also detect additional entrypoints from package.json scripts
+	extraEntrypoints := d.DetectScriptEntrypoints()
+	allEntrypoints := append(entrypoints, extraEntrypoints...)
+
+	// Seed the BFS queue from entrypoint files.
+	// We seed with ALL symbols in entrypoint files (definitions AND references)
+	// because entrypoint files often just import and call other modules (e.g.,
+	// barrel files, server startup). Only seeding definitions would miss the
+	// actual pipeline wiring.
+	for _, ep := range allEntrypoints {
+		if ep.Kind == architecture.EntrypointTest {
+			continue
+		}
+
+		doc := index.GetDocument(ep.FileId)
+		if doc == nil {
+			doc = index.GetDocument(strings.TrimPrefix(ep.FileId, d.repoRoot+"/"))
+		}
+		if doc == nil {
+			d.logger.Debug("Entrypoint document not found in SCIP index", "file", ep.FileId)
+			continue
+		}
+
+		// Collect ALL function symbols from the entrypoint file —
+		// both definitions and references. This ensures that imports like
+		// `import { createApp } from './app'` followed by `createApp()`
+		// seed the BFS with `createApp`.
+		for _, occ := range doc.Occurrences {
+			if isFunctionSymbol(occ.Symbol) {
+				if !reachable[occ.Symbol] {
+					reachable[occ.Symbol] = true
+					queue = append(queue, occ.Symbol)
+				}
+			}
+		}
+	}
+
+	d.logger.Debug("BFS seed", "entrypoints", len(allEntrypoints), "seedSymbols", len(queue))
+
+	// Phase 1: Import-graph BFS — follow file-level imports transitively.
+	// For each reachable symbol, find which file it's defined in, then add
+	// ALL symbols referenced from that file to the reachable set. This
+	// traverses module boundaries through imports, which is critical for
+	// TypeScript/Python where the SCIP call graph is shallow.
+	visitedFiles := make(map[string]bool)
+
+	// Seed visited files from entrypoints
+	for _, ep := range allEntrypoints {
+		if ep.Kind != architecture.EntrypointTest {
+			visitedFiles[ep.FileId] = true
+			trimmed := strings.TrimPrefix(ep.FileId, d.repoRoot+"/")
+			if trimmed != ep.FileId {
+				visitedFiles[trimmed] = true
+			}
+		}
+	}
+
+	fileQueue := make([]string, 0, len(visitedFiles))
+	for f := range visitedFiles {
+		fileQueue = append(fileQueue, f)
+	}
+
+	for len(fileQueue) > 0 {
+		if ctx.Err() != nil {
+			partial = true
+			break
+		}
+		if len(reachable) >= maxNodes {
+			partial = true
+			d.logger.Debug("Reachable set budget exhausted (import BFS)", "maxNodes", maxNodes)
+			break
+		}
+
+		filePath := fileQueue[0]
+		fileQueue = fileQueue[1:]
+
+		doc := index.GetDocument(filePath)
+		if doc == nil {
+			continue
+		}
+
+		// Collect all symbols referenced in this file
+		for _, occ := range doc.Occurrences {
+			if occ.Symbol == "" {
+				continue
+			}
+
+			// Mark symbol as reachable
+			if !reachable[occ.Symbol] {
+				reachable[occ.Symbol] = true
+				queue = append(queue, occ.Symbol) // also feed into call-graph BFS
+			}
+
+			// If this is an import or reference to a symbol defined in another file,
+			// add that file to the file queue
+			if loc := findSymbolFile(occ.Symbol, index); loc != "" {
+				if !visitedFiles[loc] {
+					visitedFiles[loc] = true
+					fileQueue = append(fileQueue, loc)
+				}
+			}
+		}
+	}
+
+	d.logger.Debug("After import-graph BFS", "reachableSymbols", len(reachable), "visitedFiles", len(visitedFiles))
+
+	// Phase 2: Call-graph BFS — walk callees for any remaining symbols
+	// in the queue that have callee edges. This adds depth for Go and
+	// other languages where SCIP has rich call graph data.
+	for len(queue) > 0 {
+		if ctx.Err() != nil {
+			partial = true
+			break
+		}
+		if len(reachable) >= maxNodes {
+			partial = true
+			d.logger.Debug("Reachable set budget exhausted (callee BFS)", "maxNodes", maxNodes)
+			break
+		}
+
+		sym := queue[0]
+		queue = queue[1:]
+
+		callees, err := index.FindCallees(sym)
+		if err != nil {
+			continue
+		}
+
+		for _, callee := range callees {
+			if !reachable[callee.SymbolID] {
+				reachable[callee.SymbolID] = true
+				queue = append(queue, callee.SymbolID)
+			}
+		}
+	}
+
+	d.logger.Debug("Reachable set built", "size", len(reachable), "partial", partial)
+	return reachable, partial
+}
+
+// Analyze finds unwired exported symbols not in the reachable set.
+func (d *Detector) Analyze(ctx context.Context, opts DetectorOptions, reachable map[string]bool) (*Result, error) {
+	if reachable == nil {
+		return &Result{
+			Summary: Summary{ByKind: make(map[string]int)},
+		}, nil
+	}
+
+	index := d.scipAdapter.GetIndex()
+	if index == nil {
+		return &Result{
+			Summary: Summary{ByKind: make(map[string]int)},
+		}, nil
+	}
+
+	allSymbols := d.scipAdapter.AllSymbols()
+	if allSymbols == nil {
+		return &Result{
+			Summary: Summary{ByKind: make(map[string]int)},
+		}, nil
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	minConf := opts.MinConfidence
+	if minConf <= 0 {
+		minConf = 0.80
+	}
+
+	exclusions := deadcode.NewExclusionRules(opts.ExcludePatterns)
+
+	// Group items by module (directory)
+	moduleItems := make(map[string][]UnwiredItem)
+	moduleExported := make(map[string]int)
+	totalExported := 0
+	totalUnwired := 0
+
+	for _, sym := range allSymbols {
+		if ctx.Err() != nil {
+			break
+		}
+
+		info := parseSymbolInfo(sym)
+		if info == nil {
+			continue
+		}
+
+		// Skip non-exported
+		if !info.exported {
+			continue
+		}
+
+		// Skip test files
+		if deadcode.IsTestFile(info.filePath) {
+			continue
+		}
+
+		// Skip generated files
+		if isGeneratedFile(info.filePath) {
+			continue
+		}
+
+		// Apply scope filter
+		if len(opts.Scope) > 0 && !inScope(info.filePath, opts.Scope) {
+			continue
+		}
+
+		// Skip non-callable symbols unless IncludeTypes is set
+		if !isFunctionSymbol(sym.Symbol) && !opts.IncludeTypes {
+			continue
+		}
+
+		// Skip exclusions (main, init, interface methods, etc.)
+		excl := exclusions.ShouldExclude(deadcode.SymbolInfo{
+			Name:     info.name,
+			Kind:     info.kind,
+			FilePath: info.filePath,
+			Exported: info.exported,
+		})
+		if excl != "" {
+			continue
+		}
+
+		module := filepath.Dir(info.filePath)
+		moduleExported[module]++
+		totalExported++
+
+		// Check if reachable
+		if reachable[sym.Symbol] {
+			continue
+		}
+
+		// This symbol is unwired — classify it
+		confidence, reason := d.classifyUnwired(sym, index)
+		if confidence < minConf {
+			continue
+		}
+
+		kind := info.kind
+		if isFunctionSymbol(sym.Symbol) {
+			if strings.Contains(sym.Symbol, "#") {
+				kind = "method"
+			} else {
+				kind = "function"
+			}
+		}
+
+		item := UnwiredItem{
+			SymbolID:       sym.Symbol,
+			SymbolName:     info.name,
+			Kind:           kind,
+			FilePath:       info.filePath,
+			LineNumber:     info.lineNumber,
+			Module:         module,
+			ReferenceCount: d.scipAdapter.GetReferenceCount(sym.Symbol),
+			Confidence:     confidence,
+			Reason:         reason,
+			Exported:       true,
+		}
+
+		// Count test references
+		item.TestReferences = d.countTestReferences(sym.Symbol, index)
+
+		moduleItems[module] = append(moduleItems[module], item)
+		totalUnwired++
+	}
+
+	// Build result grouped by module
+	var modules []UnwiredModule
+	byKind := make(map[string]int)
+
+	for modPath, items := range moduleItems {
+		// Sort by confidence desc
+		sort.Slice(items, func(i, j int) bool {
+			return items[i].Confidence > items[j].Confidence
+		})
+
+		for _, item := range items {
+			byKind[item.Kind]++
+		}
+
+		modules = append(modules, UnwiredModule{
+			Path:  modPath,
+			Items: items,
+			Summary: ModuleSummary{
+				TotalExported: moduleExported[modPath],
+				UnwiredCount:  len(items),
+			},
+		})
+	}
+
+	// Sort modules by unwired count desc
+	sort.Slice(modules, func(i, j int) bool {
+		return modules[i].Summary.UnwiredCount > modules[j].Summary.UnwiredCount
+	})
+
+	// Apply limit
+	if limit > 0 {
+		total := 0
+		for i := range modules {
+			total += len(modules[i].Items)
+			if total > limit {
+				modules = modules[:i+1]
+				break
+			}
+		}
+	}
+
+	return &Result{
+		UnwiredModules: modules,
+		Summary: Summary{
+			TotalExported:  totalExported,
+			ReachableCount: len(reachable),
+			UnwiredCount:   totalUnwired,
+			UnwiredModules: len(modules),
+			ByKind:         byKind,
+		},
+		ReachableCount: len(reachable),
+	}, nil
+}
+
+// classifyUnwired determines confidence and reason for an unwired symbol.
+func (d *Detector) classifyUnwired(sym *scip.SymbolInformation, index *scip.SCIPIndex) (float64, string) {
+	refCount := index.GetReferenceCount(sym.Symbol)
+	testRefs := d.countTestReferences(sym.Symbol, index)
+
+	switch {
+	case refCount == 0:
+		// No references at all — also dead code, but we still flag it
+		return 0.95, "exported with no references and not reachable from any entrypoint"
+	case testRefs == refCount:
+		// Only referenced from tests
+		return 0.95, "only referenced from tests, not reachable from any entrypoint"
+	case refCount > 0 && testRefs < refCount:
+		// Has non-test references but still not reachable — the LLMRouter pattern
+		// Other modules reference it, but nothing connects to the pipeline
+		return 0.85, "has references but not transitively reachable from any entrypoint"
+	default:
+		return 0.80, "not reachable from any entrypoint"
+	}
+}
+
+// countTestReferences counts how many references to a symbol are from test files.
+func (d *Detector) countTestReferences(symbolID string, index *scip.SCIPIndex) int {
+	count := 0
+	refs, err := index.FindReferences(symbolID, scip.ReferenceOptions{IncludeDefinition: false, IncludeTests: true})
+	if err != nil {
+		return 0
+	}
+	for _, ref := range refs {
+		if deadcode.IsTestFile(ref.Location.FileId) {
+			count++
+		}
+	}
+	return count
+}
+
+// DetectScriptEntrypoints finds additional entrypoints from package.json scripts.
+// This catches patterns like `"dev": "bun run src/server.ts"` that the standard
+// entrypoint detection misses.
+func (d *Detector) DetectScriptEntrypoints() []architecture.Entrypoint {
+	packageJSON := filepath.Join(d.repoRoot, "package.json")
+	data, err := os.ReadFile(packageJSON)
+	if err != nil {
+		return nil
+	}
+
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var entrypoints []architecture.Entrypoint
+
+	// Look for file paths in script commands (dev, start, serve, main)
+	for name, cmd := range pkg.Scripts {
+		if name == "test" || name == "lint" || name == "lint:fix" ||
+			name == "format" || name == "check" || name == "build" {
+			continue
+		}
+
+		// Extract .ts/.js file paths from the command
+		for _, part := range strings.Fields(cmd) {
+			if (strings.HasSuffix(part, ".ts") || strings.HasSuffix(part, ".js")) &&
+				!strings.HasPrefix(part, "-") && !strings.HasPrefix(part, "node_modules") {
+				if !seen[part] {
+					seen[part] = true
+					kind := architecture.EntrypointServer
+					if strings.Contains(name, "cli") || name == "bin" {
+						kind = architecture.EntrypointCLI
+					}
+					entrypoints = append(entrypoints, architecture.Entrypoint{
+						FileId: part,
+						Name:   filepath.Base(part),
+						Kind:   kind,
+					})
+				}
+			}
+		}
+	}
+
+	return entrypoints
+}
+
+// --- Symbol parsing helpers ---
+
+type symbolInfo struct {
+	name       string
+	kind       string
+	filePath   string
+	lineNumber int
+	exported   bool
+}
+
+func parseSymbolInfo(sym *scip.SymbolInformation) *symbolInfo {
+	if sym == nil || sym.Symbol == "" {
+		return nil
+	}
+
+	name := sym.DisplayName
+	if name == "" {
+		name = extractName(sym.Symbol)
+	}
+	if name == "" {
+		return nil
+	}
+
+	// Find definition location
+	filePath := ""
+	lineNumber := 0
+	// Symbol ID contains the file path for scip-go: "scip-go gomod pkg/file.go/SymbolName"
+	parts := strings.Fields(sym.Symbol)
+	if len(parts) >= 3 {
+		// Extract path from the descriptor portion
+		for _, p := range parts[2:] {
+			if strings.Contains(p, "/") && (strings.HasSuffix(p, ".go") || strings.Contains(p, ".go/") ||
+				strings.HasSuffix(p, ".ts") || strings.Contains(p, ".ts/") ||
+				strings.HasSuffix(p, ".py") || strings.Contains(p, ".py/") ||
+				strings.HasSuffix(p, ".rs") || strings.Contains(p, ".rs/")) {
+				// Extract just the file path portion
+				if idx := strings.Index(p, ".go/"); idx >= 0 {
+					filePath = p[:idx+3]
+				} else if idx := strings.Index(p, ".ts/"); idx >= 0 {
+					filePath = p[:idx+3]
+				} else if idx := strings.Index(p, ".py/"); idx >= 0 {
+					filePath = p[:idx+3]
+				} else if idx := strings.Index(p, ".rs/"); idx >= 0 {
+					filePath = p[:idx+3]
+				} else {
+					filePath = p
+				}
+				break
+			}
+		}
+	}
+
+	kind := "type"
+	if isFunctionSymbol(sym.Symbol) {
+		kind = "function"
+	}
+
+	exported := isExported(name)
+
+	return &symbolInfo{
+		name:       name,
+		kind:       kind,
+		filePath:   filePath,
+		lineNumber: lineNumber,
+		exported:   exported,
+	}
+}
+
+func extractName(symbolID string) string {
+	// Extract the last component of the SCIP symbol ID
+	parts := strings.Split(symbolID, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	last := parts[len(parts)-1]
+	// Remove trailing descriptor markers
+	last = strings.TrimSuffix(last, "().")
+	last = strings.TrimSuffix(last, "#")
+	last = strings.TrimSuffix(last, ".")
+	return last
+}
+
+func isExported(name string) bool {
+	if name == "" {
+		return false
+	}
+	r := []rune(name)
+	return unicode.IsUpper(r[0])
+}
+
+func isFunctionSymbol(symbolID string) bool {
+	return strings.Contains(symbolID, "().")
+}
+
+// findSymbolFile returns the file path where a symbol is defined.
+// Returns empty string if not found.
+func findSymbolFile(symbolID string, index *scip.SCIPIndex) string {
+	// Fast path: check the Symbols map for location info
+	if sym := index.GetSymbol(symbolID); sym != nil {
+		// Try to extract file path from the symbol ID itself.
+		// SCIP symbol IDs encode the file: e.g.,
+		//   scip-typescript npm pkg 1.0.0 src/router/`app.ts`/createApp().
+		//   scip-go gomod pkg src/internal/query/engine.go/Engine#GetStatus().
+		if path := extractFileFromSymbolID(symbolID); path != "" {
+			return path
+		}
+	}
+
+	// Slow path: scan documents for definition occurrence
+	for _, doc := range index.Documents {
+		for _, occ := range doc.Occurrences {
+			if occ.Symbol == symbolID && occ.SymbolRoles&scip.SymbolRoleDefinition != 0 {
+				return doc.RelativePath
+			}
+		}
+	}
+	return ""
+}
+
+// extractFileFromSymbolID extracts the file path from a SCIP symbol ID.
+// TypeScript: scip-typescript npm pkg 1.0.0 src/router/`app.ts`/createApp().
+// Go: scip-go gomod github.com/pkg v1.0.0 src/file.go/Symbol().
+func extractFileFromSymbolID(symbolID string) string {
+	// TypeScript pattern: backtick-quoted file names
+	if idx := strings.Index(symbolID, "`"); idx >= 0 {
+		end := strings.Index(symbolID[idx+1:], "`")
+		if end >= 0 {
+			// Extract the path prefix before the backtick + the filename
+			// e.g., "scip-typescript npm llmrouter 0.1.0 src/router/`app.ts`/createApp()."
+			// We want "src/router/app.ts"
+			prefix := symbolID[:idx]
+			fileName := symbolID[idx+1 : idx+1+end]
+
+			// Find the last space before the backtick to get the path start
+			parts := strings.Fields(prefix)
+			if len(parts) > 0 {
+				dirPart := parts[len(parts)-1]
+				return dirPart + fileName
+			}
+		}
+	}
+
+	// Go pattern: look for .go/ in the symbol ID
+	for _, ext := range []string{".go/", ".ts/", ".py/", ".rs/", ".js/"} {
+		if idx := strings.Index(symbolID, ext); idx >= 0 {
+			// Walk backward to find the start of the path
+			pathEnd := idx + len(ext) - 1 // include the extension, not the trailing /
+			pathPart := symbolID[:pathEnd]
+			// Find the last space (after version)
+			if spaceIdx := strings.LastIndex(pathPart, " "); spaceIdx >= 0 {
+				return pathPart[spaceIdx+1:]
+			}
+		}
+	}
+
+	return ""
+}
+
+func isGeneratedFile(path string) bool {
+	base := filepath.Base(path)
+	return strings.HasSuffix(base, ".pb.go") ||
+		strings.HasSuffix(base, "_generated.go") ||
+		strings.HasSuffix(base, "_gen.go") ||
+		strings.HasPrefix(base, "zz_generated") ||
+		base == "wire_gen.go"
+}
+
+func inScope(filePath string, scope []string) bool {
+	for _, s := range scope {
+		if strings.HasPrefix(filePath, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/unwired/types.go
+++ b/internal/unwired/types.go
@@ -1,0 +1,58 @@
+package unwired
+
+// UnwiredItem represents an exported symbol that is never transitively
+// reachable from any application entrypoint.
+type UnwiredItem struct {
+	SymbolID       string  `json:"symbolId"`
+	SymbolName     string  `json:"symbolName"`
+	Kind           string  `json:"kind"`
+	FilePath       string  `json:"filePath"`
+	LineNumber     int     `json:"lineNumber,omitempty"`
+	Module         string  `json:"module"`
+	ReferenceCount int     `json:"referenceCount"`
+	TestReferences int     `json:"testReferences,omitempty"`
+	Confidence     float64 `json:"confidence"`
+	Reason         string  `json:"reason"`
+	Exported       bool    `json:"exported"`
+}
+
+// UnwiredModule groups unwired items by directory/module.
+type UnwiredModule struct {
+	Path    string        `json:"path"`
+	Items   []UnwiredItem `json:"items"`
+	Summary ModuleSummary `json:"summary"`
+}
+
+// ModuleSummary provides per-module aggregate stats.
+type ModuleSummary struct {
+	TotalExported int `json:"totalExported"`
+	UnwiredCount  int `json:"unwiredCount"`
+}
+
+// Result is the output of the unwired module detector.
+type Result struct {
+	UnwiredModules []UnwiredModule `json:"unwiredModules"`
+	Summary        Summary         `json:"summary"`
+	Entrypoints    []string        `json:"entrypoints"`
+	ReachableCount int             `json:"reachableCount"`
+	Partial        bool            `json:"partial,omitempty"`
+}
+
+// Summary provides aggregate statistics.
+type Summary struct {
+	TotalExported  int            `json:"totalExported"`
+	ReachableCount int            `json:"reachableCount"`
+	UnwiredCount   int            `json:"unwiredCount"`
+	UnwiredModules int            `json:"unwiredModules"`
+	ByKind         map[string]int `json:"byKind"`
+}
+
+// DetectorOptions configures the unwired module detector.
+type DetectorOptions struct {
+	Scope           []string `json:"scope,omitempty"`
+	ExcludePatterns []string `json:"excludePatterns,omitempty"`
+	MaxNodes        int      `json:"maxNodes"`
+	MinConfidence   float64  `json:"minConfidence"`
+	IncludeTypes    bool     `json:"includeTypes"`
+	Limit           int      `json:"limit"`
+}


### PR DESCRIPTION
## Summary
- New check that detects exported symbols never transitively reachable from application entrypoints — catches the "built but never plugged in" pattern (e.g., modules that are tested but never called from the main pipeline)
- BFS forward from entrypoint files using SCIP call graph with 10K node budget
- Exposed via all 4 interfaces: CLI (`ckb unwired`), HTTP API (`GET /unwired`), MCP (`findUnwiredModules`), PR Review (21st check)

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go vet ./...` no warnings
- [x] `gofmt` clean
- [x] MCP preset/token budget tests pass (tool counts updated 96→97, 40→41)
- [x] Review engine tests pass
- [ ] Manual: `./ckb unwired` on a repo with unwired modules
- [ ] Manual: `curl localhost:8080/unwired` via HTTP API
- [ ] Manual: test against LLMRouter repo (the motivating case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)