### PR TITLE
fix: rename 'commit' column to 'commit_hash' in federation schema

### DIFF
--- a/internal/federation/index.go
+++ b/internal/federation/index.go
@@ -249,7 +249,7 @@ CREATE TABLE IF NOT EXISTS remote_repos (
     repo_id TEXT NOT NULL,
     name TEXT,
     description TEXT,
-    commit TEXT,
+    commit_hash TEXT,
     languages TEXT,                    -- JSON array
     symbol_count INTEGER,
     file_count INTEGER,
@@ -379,7 +379,7 @@ func (idx *Index) migrate(fromVersion int) error {
 			repo_id TEXT NOT NULL,
 			name TEXT,
 			description TEXT,
-			commit TEXT,
+			commit_hash TEXT,
 			languages TEXT,
 			symbol_count INTEGER,
 			file_count INTEGER,
@@ -667,7 +667,7 @@ type CachedRemoteRepo struct {
 func (idx *Index) UpsertRemoteRepo(repo *CachedRemoteRepo) error {
 	_, err := idx.db.Exec(`
 		INSERT OR REPLACE INTO remote_repos
-		(server_name, repo_id, name, description, commit, languages, symbol_count, file_count, sync_seq, index_version, cached_at)
+		(server_name, repo_id, name, description, commit_hash, languages, symbol_count, file_count, sync_seq, index_version, cached_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, repo.ServerName, repo.RepoID, repo.Name, repo.Description, repo.Commit,
 		repo.Languages, repo.SymbolCount, repo.FileCount, repo.SyncSeq, repo.IndexVersion,
@@ -678,7 +678,7 @@ func (idx *Index) UpsertRemoteRepo(repo *CachedRemoteRepo) error {
 // GetRemoteRepos returns all cached repos for a server
 func (idx *Index) GetRemoteRepos(serverName string) ([]*CachedRemoteRepo, error) {
 	rows, err := idx.db.Query(`
-		SELECT server_name, repo_id, name, description, commit, languages,
+		SELECT server_name, repo_id, name, description, commit_hash, languages,
 			   symbol_count, file_count, sync_seq, index_version, cached_at
 		FROM remote_repos WHERE server_name = ? ORDER BY repo_id
 	`, serverName)
@@ -709,7 +709,7 @@ func (idx *Index) GetRemoteRepos(serverName string) ([]*CachedRemoteRepo, error)
 // GetAllRemoteRepos returns all cached repos from all servers
 func (idx *Index) GetAllRemoteRepos() ([]*CachedRemoteRepo, error) {
 	rows, err := idx.db.Query(`
-		SELECT server_name, repo_id, name, description, commit, languages,
+		SELECT server_name, repo_id, name, description, commit_hash, languages,
 			   symbol_count, file_count, sync_seq, index_version, cached_at
 		FROM remote_repos ORDER BY server_name, repo_id
 	`)


### PR DESCRIPTION
## Summary

`ckb federation create` fails on all platforms because `commit` is used as an unquoted column name in the `remote_repos` table schema. `COMMIT` is a [SQLite reserved keyword](https://www.sqlite.org/lang_keywords.html), and the `modernc.org/sqlite` driver enforces this strictly.

## Error

```
Error: failed to create federation: failed to create index: failed to initialize schema:
failed to create schema: SQL logic error: near "commit": syntax error (1)
```

## Fix

Rename the column from `commit` to `commit_hash` in all 5 occurrences:

| Location | Line | Change |
|----------|------|--------|
| `remote_repos` CREATE TABLE | 252 | `commit TEXT` → `commit_hash TEXT` |
| `remote_repos` migration | 382 | `commit TEXT` → `commit_hash TEXT` |
| `UpsertRemoteRepo` INSERT | 670 | column list updated |
| `GetRemoteRepos` SELECT | 681 | column list updated |
| `GetAllRemoteRepos` SELECT | 712 | column list updated |

The Go struct field `CachedRemoteRepo.Commit` is **unchanged** — `rows.Scan()` uses positional binding, not column name mapping, so the field name is decoupled from the SQL column name.

## Testing

- Verified the column rename resolves the schema creation error
- No other files reference `remote_repos.commit` directly
- `churn_commits_30d` and `tx.Commit()` (transaction commit) are unaffected — different tokens

## Impact

This is a **blocking bug** — federation is completely unusable without this fix. No workaround exists since schema initialization is the entry point for all federation operations.

Fixes #201