### PR TITLE
feat: NoAutoFetch parity for summarizePr/summarizeDiff + gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@ bin/
 /ckb
 /ckb-test
 /ckb-bench
+/ckb_fresh
 coverage.out
 *_test
+*.test
 *.scip
 
 # Registry / credential tokens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to CKB will be documented in this file.
 
 ### Added
 
+- `NoAutoFetch` option on `SummarizePROptions` and `SummarizeDiffOptions`
+  for parity with `ReviewPROptions`. Previously the air-gapped opt-out
+  applied only to `ckb review`; MCP/HTTP callers of `summarizePr` and
+  `summarizeDiff` had no way to disable auto-fetch.
 - Troubleshooting section in `docs/plans/review-cicd.md` covering shallow
   CI clones, auth-failure remediation (`persistCredentials`), air-gapped
   pipelines, and depth-0 checkout alternatives.

--- a/internal/query/navigation.go
+++ b/internal/query/navigation.go
@@ -1879,6 +1879,7 @@ type SummarizeDiffOptions struct {
 	CommitRange *CommitRangeSelector `json:"commitRange,omitempty"`
 	Commit      string               `json:"commit,omitempty"`
 	TimeWindow  *TimeWindowSelector  `json:"timeWindow,omitempty"`
+	NoAutoFetch bool                 `json:"noAutoFetch,omitempty"` // Disable auto-fetch of missing refs (see ReviewPROptions)
 }
 
 // CommitRangeSelector specifies a base..head range.
@@ -2026,11 +2027,13 @@ func (e *Engine) SummarizeDiff(ctx context.Context, opts SummarizeDiffOptions) (
 		selector = DiffSelector{Type: "commitRange", Value: opts.CommitRange.Base + ".." + opts.CommitRange.Head}
 		base = opts.CommitRange.Base
 		head = opts.CommitRange.Head
-		if resolved, rerr := e.gitAdapter.EnsureRef(base); rerr == nil {
-			base = resolved
-		}
-		if resolved, rerr := e.gitAdapter.EnsureRef(head); rerr == nil {
-			head = resolved
+		if !opts.NoAutoFetch {
+			if resolved, rerr := e.gitAdapter.EnsureRef(base); rerr == nil {
+				base = resolved
+			}
+			if resolved, rerr := e.gitAdapter.EnsureRef(head); rerr == nil {
+				head = resolved
+			}
 		}
 		diffStats, err = e.gitAdapter.GetCommitRangeDiff(base, head)
 		if err != nil {

--- a/internal/query/pr.go
+++ b/internal/query/pr.go
@@ -16,6 +16,7 @@ type SummarizePROptions struct {
 	BaseBranch       string `json:"baseBranch"`       // Base branch to compare against (default: "main")
 	HeadBranch       string `json:"headBranch"`       // Head branch (default: current branch)
 	IncludeOwnership bool   `json:"includeOwnership"` // Include ownership analysis (default: true)
+	NoAutoFetch      bool   `json:"noAutoFetch"`      // Disable auto-fetch of missing base ref (see ReviewPROptions)
 }
 
 // SummarizePRResponse is the response for summarize-pr.
@@ -102,11 +103,20 @@ func (e *Engine) SummarizePR(ctx context.Context, opts SummarizePROptions) (*Sum
 	if headRef == "" {
 		headRef = "HEAD"
 	}
-	baseRef, err := e.gitAdapter.EnsureRef(opts.BaseBranch)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve base ref %q: %w", opts.BaseBranch, err)
+	var baseRef string
+	if opts.NoAutoFetch {
+		if verr := e.gitAdapter.VerifyRef(opts.BaseBranch); verr != nil {
+			return nil, fmt.Errorf("failed to resolve base ref %q: %w", opts.BaseBranch, verr)
+		}
+		baseRef = opts.BaseBranch
+	} else {
+		resolved, rerr := e.gitAdapter.EnsureRef(opts.BaseBranch)
+		if rerr != nil {
+			return nil, fmt.Errorf("failed to resolve base ref %q: %w", opts.BaseBranch, rerr)
+		}
+		baseRef = resolved
+		opts.BaseBranch = resolved
 	}
-	opts.BaseBranch = baseRef
 	diffStats, err := e.gitAdapter.GetCommitRangeDiff(baseRef, headRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get diff: %w", err)


### PR DESCRIPTION
## Summary

Closes two loose ends from the 9.0.1 / 9.1.0 shallow-CI-clone work.

- **Parity fix** — 9.1.0 added `--no-auto-fetch` / `ReviewPROptions.NoAutoFetch`, but `summarizePr` (`pr.go`) and `summarizeDiff` (`navigation.go`) still auto-fetched unconditionally. Air-gapped MCP/HTTP callers now have a consistent opt-out across all three review-adjacent tools.
- **Housekeeping** — add `/ckb_fresh` and `*.test` to `.gitignore` so local dev-build binaries and compiled Go test binaries in repo root stop showing as untracked.

## Details

**`SummarizePROptions.NoAutoFetch`** — when true, routes through `VerifyRef` (local-only rev-parse check) instead of `EnsureRef` (fetches on miss). Same pattern already used in `review.go`.

**`SummarizeDiffOptions.NoAutoFetch`** — applies to the `CommitRange` path where user-supplied base/head refs are resolved. Other selectors (`Commit`, `TimeWindow`) operate on local SHAs so they're unaffected.

No CLI flags added — these two tools are MCP/HTTP-only.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/query/ ./internal/backends/git/` passes
- [x] Verified `ckb_fresh` / `scip.test` no longer surface in `git status`
- [ ] Manual: MCP caller with `noAutoFetch: true` fails cleanly on missing ref instead of fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)