### PR TITLE
fix(review): --checks help omitted "unwired"

### DIFF
--- a/cmd/ckb/review.go
+++ b/cmd/ckb/review.go
@@ -122,7 +122,11 @@ func init() {
 	reviewCmd.Flags().StringVar(&reviewFormat, "format", "human", "Output format (human, json, markdown, github-actions, sarif, codeclimate, compliance)")
 	reviewCmd.Flags().StringVar(&reviewBaseBranch, "base", "main", "Base branch to compare against")
 	reviewCmd.Flags().StringVar(&reviewHeadBranch, "head", "", "Head branch (default: current branch)")
-	reviewCmd.Flags().StringSliceVar(&reviewChecks, "checks", nil, "Comma-separated list of checks to run (breaking,secrets,tests,complexity,coupling,hotspots,risk,critical,generated,classify,split,health,traceability,independence,dead-code,test-gaps,blast-radius,comment-drift,format-consistency,bug-patterns)")
+	// Keep this list in sync with the checkEnabled() gates in
+	// internal/query/review.go. It omitted "unwired" for several releases,
+	// which is where the recurring "20 checks vs 21 checks" doc discrepancy
+	// came from — the help string was the only enumeration users could see.
+	reviewCmd.Flags().StringSliceVar(&reviewChecks, "checks", nil, "Comma-separated list of checks to run (breaking,secrets,tests,complexity,coupling,hotspots,risk,critical,generated,classify,split,health,traceability,independence,dead-code,unwired,test-gaps,blast-radius,comment-drift,format-consistency,bug-patterns). Three more run only when their backend is available: arch-health and layers (Cartographer), semantic-novelty (LIP)")
 	reviewCmd.Flags().StringSliceVar(&reviewSkipChecks, "skip", nil, "Comma-separated list of checks to skip (complement of --checks; useful to exclude SCIP-heavy checks on large repos)")
 	reviewCmd.Flags().BoolVar(&reviewCI, "ci", false, "CI mode: exit 1 on fail, exit 2 on warn")
 	reviewCmd.Flags().StringVar(&reviewFailOn, "fail-on", "", "Override fail level (error, warning, none)")


### PR DESCRIPTION
## Problem

`ckb review --checks` listed 20 check names while `checkEnabled()` in `internal/query/review.go` gates **21 that always run** — `unwired` was missing from the help, even though the command's own examples used it:

```
ckb review --skip=dead-code,blast-radius,unwired
```

Three further checks are gated on a backend being present and are not in the always-run set: `arch-health` and `layers` (Cartographer), `semantic-novelty` (LIP). That's 24 reachable via `checkEnabled()`, 21 unconditional.

## Why it mattered

This help string is the only enumeration of check names a user can see, so it became the de-facto source of truth and seeded a long-running "20 vs 21 checks" contradiction in the docs. A wiki page was reverted from 21 to 20 three months ago on the strength of it, against six other pages that said 21 — the docs have now been corrected to 21 in the wiki, with the count traced back to the `checkEnabled()` gates rather than to this string.

## Change

- Adds `unwired` to the `--checks` list (20 → 21).
- Documents the three backend-gated checks in the help text.
- Adds a comment tying the list to the `checkEnabled()` gates so the two don't silently drift again.

Help-text only — no behavior change. `unwired` was always selectable; it just wasn't discoverable.

## Verification

```
go build ./cmd/ckb        # ok
go test ./cmd/ckb/...     # ok
```

`ckb review --help` now lists 21 names, matching the gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)